### PR TITLE
Allow CRD2Go to selectively render Kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ go tool crd2go -h
 Usage of ./crd2go:
   -config string
     	YAML file with the CRD2Go config (default "crd2go.yaml")
+  -generate string
+    	comma separated list o kinds to actually generate code for. Empty, the default value, genrates all Kinds. In any case, all CRDs are processed, unlike with skip.
   -input string
     	input YAML to process
   -output string
@@ -25,6 +27,7 @@ Usage of ./crd2go:
 
 Main arguments:
 - **config** is the name of a YAML file containing all tool settings.
+- **generate** allows to select a subset of CRD Kind types to render, even after processing the corresponding CRD to keep the type name ans sharing decisions unchanged. This is a CLI only argument, not present in the config file.
 - **input** is the name of a YAML file with one or more CRDs to generate Go code from.
 - **output** is the directory where the Go types for the CRDs should be generated.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go tool crd2go -h
 Usage of ./crd2go:
   -config string
     	YAML file with the CRD2Go config (default "crd2go.yaml")
-  -generate string
+  -kinds string
     	comma separated list of kinds to actually generate code for. Empty, the default value, generates all Kinds. In any case, all CRDs are processed, unlike with skip.
   -input string
     	input YAML to process
@@ -27,7 +27,7 @@ Usage of ./crd2go:
 
 Main arguments:
 - **config** is the name of a YAML file containing all tool settings.
-- **generate** allows to select a subset of CRD Kind types to render, even after processing the corresponding CRD to keep the type name ans sharing decisions unchanged. This is a CLI only argument, not present in the config file.
+- **kinds** allows to select a subset of CRD Kind types to render, even after processing the corresponding CRD to keep the type name ans sharing decisions unchanged. This is a CLI only argument, not present in the config file.
 - **input** is the name of a YAML file with one or more CRDs to generate Go code from.
 - **output** is the directory where the Go types for the CRDs should be generated.
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ go tool crd2go -h
 Usage of ./crd2go:
   -config string
     	YAML file with the CRD2Go config (default "crd2go.yaml")
-  -kinds string
-    	comma separated list of kinds to actually generate code for. Empty, the default value, generates all Kinds. In any case, all CRDs are processed, unlike with skip.
   -input string
     	input YAML to process
+  -kinds string
+    	comma separated list of Kinds to consider for generation. If empty, it generates all Kinds.
   -output string
     	output directory to produce source code to
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage of ./crd2go:
   -config string
     	YAML file with the CRD2Go config (default "crd2go.yaml")
   -generate string
-    	comma separated list o kinds to actually generate code for. Empty, the default value, genrates all Kinds. In any case, all CRDs are processed, unlike with skip.
+    	comma separated list of kinds to actually generate code for. Empty, the default value, generates all Kinds. In any case, all CRDs are processed, unlike with skip.
   -input string
     	input YAML to process
   -output string

--- a/cmd/crd2go/main.go
+++ b/cmd/crd2go/main.go
@@ -29,16 +29,16 @@ import (
 )
 
 func main() {
-	var input, output, generate, config string
+	var input, output, kinds, config string
 	flag.StringVar(&input, "input", "", "input YAML to process")
 	flag.StringVar(&output, "output", "", "output directory to produce source code to")
-	flag.StringVar(&generate, "generate", "", "comma separated list of kinds to actually "+
+	flag.StringVar(&kinds, "kinds", "", "comma separated list of kinds to actually "+
 		"generate code for. Empty, the default value, generates all Kinds. "+
 		"In any case, all CRDs are processed, unlike with skip.")
 	flag.StringVar(&config, "config", "crd2go.yaml", "YAML file with the CRD2Go config")
 	flag.Parse()
 
-	cfg, err := generateTypes(input, output, config, asList(generate))
+	cfg, err := generateTypes(input, output, config, asList(kinds))
 	if err != nil {
 		log.Fatalf("Failed to generate go structs: %v", err)
 	}

--- a/cmd/crd2go/main.go
+++ b/cmd/crd2go/main.go
@@ -32,9 +32,8 @@ func main() {
 	var input, output, kinds, config string
 	flag.StringVar(&input, "input", "", "input YAML to process")
 	flag.StringVar(&output, "output", "", "output directory to produce source code to")
-	flag.StringVar(&kinds, "kinds", "", "comma separated list of kinds to actually "+
-		"generate code for. Empty, the default value, generates all Kinds. "+
-		"In any case, all CRDs are processed, unlike with skip.")
+	flag.StringVar(&kinds, "kinds", "", "comma separated list of Kinds to consider for generation. "+
+		"If empty, it generates all Kinds.")
 	flag.StringVar(&config, "config", "crd2go.yaml", "YAML file with the CRD2Go config")
 	flag.Parse()
 

--- a/cmd/crd2go/main.go
+++ b/cmd/crd2go/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/crd2go/crd2go/internal/checkerr"
 	"github.com/crd2go/crd2go/internal/fileinput"
@@ -28,20 +29,23 @@ import (
 )
 
 func main() {
-	var input, output, config string
+	var input, output, generate, config string
 	flag.StringVar(&input, "input", "", "input YAML to process")
 	flag.StringVar(&output, "output", "", "output directory to produce source code to")
+	flag.StringVar(&generate, "generate", "", "comma separated list o kinds to actually "+
+		"generate code for. Empty, the default value, genrates all Kinds. "+
+		"In any case, all CRDs are processed, unlike with skip.")
 	flag.StringVar(&config, "config", "crd2go.yaml", "YAML file with the CRD2Go config")
 	flag.Parse()
 
-	cfg, err := generate(input, output, config)
+	cfg, err := generateTypes(input, output, config, asList(generate))
 	if err != nil {
 		log.Fatalf("Failed to generate go structs: %v", err)
 	}
 	log.Printf("Code generated at %s", cfg.Output)
 }
 
-func generate(input, output, config string) (*config.Config, error) {
+func generateTypes(input, output, config string, kinds []string) (*config.Config, error) {
 	f, err := os.Open(fileinput.MustBeSafe(config))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open configuration file: %w", err)
@@ -57,8 +61,20 @@ func generate(input, output, config string) (*config.Config, error) {
 	if output != "" {
 		cfg.Output = output
 	}
+	cfg.Kinds = kinds
 	if err := crd2go.GenerateToDir(cfg); err != nil {
 		return nil, fmt.Errorf("failed to generate code: %w", err)
 	}
 	return cfg, nil
+}
+
+func asList(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	results := strings.Split(s, ",")
+	for i, item := range results {
+		results[i] = strings.TrimSpace(item)
+	}
+	return results
 }

--- a/cmd/crd2go/main.go
+++ b/cmd/crd2go/main.go
@@ -32,8 +32,8 @@ func main() {
 	var input, output, generate, config string
 	flag.StringVar(&input, "input", "", "input YAML to process")
 	flag.StringVar(&output, "output", "", "output directory to produce source code to")
-	flag.StringVar(&generate, "generate", "", "comma separated list o kinds to actually "+
-		"generate code for. Empty, the default value, genrates all Kinds. "+
+	flag.StringVar(&generate, "generate", "", "comma separated list of kinds to actually "+
+		"generate code for. Empty, the default value, generates all Kinds. "+
 		"In any case, all CRDs are processed, unlike with skip.")
 	flag.StringVar(&config, "config", "crd2go.yaml", "YAML file with the CRD2Go config")
 	flag.Parse()

--- a/internal/gotype/typedict.go
+++ b/internal/gotype/typedict.go
@@ -17,6 +17,7 @@ package gotype
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/crd2go/crd2go/pkg/config"
 )
@@ -35,6 +36,20 @@ type Request struct {
 	config.CoreConfig
 	CodeWriterFn config.CodeWriterFunc
 	TypeDict     *TypeDict
+}
+
+// RenderKind returns true if the given kind must be rendered. Which happens
+// when either the Kinds list in config is empty or the kind is contained in it
+func (req *Request) RenderKind(kind string) bool {
+	if len(req.Kinds) == 0 {
+		return true
+	}
+	for _, allowedKind := range req.Kinds {
+		if strings.EqualFold(allowedKind, kind) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewTypeDict creates a new TypeDict with the given renames and Go types

--- a/internal/gotype/typedict_test.go
+++ b/internal/gotype/typedict_test.go
@@ -258,3 +258,37 @@ func TestTypeDict_RenameField(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderKind(t *testing.T) {
+	for _, tc := range []struct {
+		title  string
+		kinds  []string
+		target string
+		want   bool
+	}{
+		{
+			title:  "allow all",
+			kinds:  []string{},
+			target: "akind",
+			want:   true,
+		},
+		{
+			title:  "allow akind",
+			kinds:  []string{"akind"},
+			target: "akind",
+			want:   true,
+		},
+		{
+			title:  "skip akind",
+			kinds:  []string{"bkind", "ckind"},
+			target: "akind",
+			want:   false,
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			req := Request{}
+			req.Kinds = tc.kinds
+			assert.Equal(t, tc.want, req.RenderKind(tc.target))
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ type CoreConfig struct {
 	Renames  map[string]string    `yaml:"renames"`
 	Imports  []ImportedTypeConfig `yaml:"imports"`
 	DeepCopy DeepCopy             `yaml:"deepCopy"`
+	Kinds    []string             `yaml:"-"` // only a CLI arg
 }
 
 type DeepCopy struct {

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -165,6 +165,10 @@ func GenerateStream(req *gotype.Request, r io.Reader) ([]string, error) {
 			return nil, fmt.Errorf("could not build CRD type: %w", err)
 		}
 
+		if !req.RenderKind(versionedCRD.Kind) {
+			continue
+		}
+
 		renderReq := render.CRDRenderRequest{
 			Request:  *req,
 			Filename: crd.Kind2Filename(versionedCRD.Kind),

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -69,6 +69,34 @@ func TestGenerateFromCRDs(t *testing.T) {
 	}
 }
 
+func TestSelectivelyGenerateFromCRDs(t *testing.T) {
+	buffers := make(map[string]*bytes.Buffer)
+
+	in, err := samples.Open("samples/crds.yaml")
+	require.NoError(t, err)
+	req := gotype.Request{
+		CodeWriterFn: BufferForCRD(buffers),
+		TypeDict:     gotype.NewTypeDict(nil, preloadedTypes()...),
+		CoreConfig: config.CoreConfig{
+			Version:  crd.FirstVersion,
+			SkipList: disabledKinds,
+			Kinds: []string{
+				"Organization", "Group", "Cluster",
+				"FlexCluster", "GroupAlertsConfig", "ThirdPartyIntegration",
+			},
+		},
+	}
+	require.NoError(t, Generate(&req, in))
+
+	assert.NotEmpty(t, buffers)
+	expectedGenerations := 8 // 6 CRDs and the docs and schame files
+	assert.Len(t, buffers, expectedGenerations)
+	for key, buf := range buffers {
+		want := readTestFile(t, filepath.Join("samples", "v1", key))
+		require.Equal(t, want, buf.String())
+	}
+}
+
 func TestRefs(t *testing.T) {
 	buffers := make(map[string]*bytes.Buffer)
 


### PR DESCRIPTION
All CRDs are still processed, that way the type names and type sharing decisions are not changed as compared to rendering all types. This is the behaviour expected when a set of types hash already been generated and only a subset needs to be updated.