### PR TITLE
Fail if YAML contains different group versions

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -22,8 +22,10 @@ import (
 type CRDRenderRequest struct {
 	gotype.Request
 	Filename string
+	Group    string
 	Version  string
 	Kind     string
+	Resource string
 	Type     *gotype.GoType
 }
 

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -96,29 +96,24 @@ func GenerateToDir(cfg *config.Config) error {
 
 // Generate will write files using the CodeWriterFunc
 func Generate(req *gotype.Request, r io.Reader) error {
-	groupsVersions := map[string]struct{}{}
-	group := ""
-	version := ""
 	generatedGVRs, err := GenerateStream(req, r)
 	if err != nil {
 		return fmt.Errorf("failed to generate CRDs: %w", err)
 	}
-	for _, gvr := range generatedGVRs {
-		parts := strings.Split(gvr, "/")
-		if len(parts) > 2 {
-			group = parts[0]
-			version = parts[1]
-			gv := fmt.Sprintf("%s/%s", group, version)
-			groupsVersions[gv] = struct{}{}
-		}
+	if len(generatedGVRs) <= 0 {
+		return nil
 	}
-	if len(groupsVersions) == 1 {
-		if err := render.Default.RenderDoc(req, group, version); err != nil {
-			return fmt.Errorf("failed to generate the doc.go file for group version '%s/%s': %w", group, version, err)
-		}
-		if err := render.Default.RenderSchema(req, group, version); err != nil {
-			return fmt.Errorf("failed to generate the schema.go file for group version '%s/%s': %w", group, version, err)
-		}
+	parts := strings.Split(generatedGVRs[0], "/")
+	if len(parts) <= 2 {
+		return nil
+	}
+	group := parts[0]
+	version := parts[1]
+	if err := render.Default.RenderDoc(req, group, version); err != nil {
+		return fmt.Errorf("failed to generate the doc.go file for group version '%s/%s': %w", group, version, err)
+	}
+	if err := render.Default.RenderSchema(req, group, version); err != nil {
+		return fmt.Errorf("failed to generate the schema.go file for group version '%s/%s': %w", group, version, err)
 	}
 	return nil
 }
@@ -135,17 +130,36 @@ func GenerateStream(req *gotype.Request, r io.Reader) ([]string, error) {
 	for _, importType := range req.Imports {
 		preloaded = append(preloaded, gotype.NewAutoImportType(&importType))
 	}
-	generatedGVRs := []string{}
-	generated := false
-	scanner := bufio.NewScanner(r)
 	req.TypeDict.AddAll(preloaded...)
+
+	renderRequests, err := computeRenderRequests(req, bufio.NewScanner(r))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CRDs code generation information: %w", err)
+	}
+
+	generatedGVRs := []string{}
+	for _, renderReq := range renderRequests {
+		if err := render.Default.RenderCRD(&renderReq); err != nil {
+			return nil, fmt.Errorf("failed to generate CRD code: %w", err)
+		}
+		gvr := fmt.Sprintf("%s/%s/%s", renderReq.Group, renderReq.Version, renderReq.Resource)
+		gvr = strings.TrimPrefix(gvr, "/")
+		generatedGVRs = append(generatedGVRs, gvr)
+	}
+	return generatedGVRs, nil
+}
+
+func computeRenderRequests(req *gotype.Request, scanner *bufio.Scanner) ([]render.CRDRenderRequest, error) {
+	renderRequests := []render.CRDRenderRequest{}
+	group := ""
+	version := ""
 	for {
 		crdSchema, err := crd.ParseCRD(scanner)
 		if errors.Is(err, io.EOF) {
-			if generated {
-				return generatedGVRs, nil
+			if len(renderRequests) == 0 {
+				return nil, fmt.Errorf("failed to parse CRD: %w", err)
 			}
-			return nil, fmt.Errorf("failed to parse CRD: %w", err)
+			return renderRequests, nil
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read input: %w", err)
@@ -165,21 +179,26 @@ func GenerateStream(req *gotype.Request, r io.Reader) ([]string, error) {
 			return nil, fmt.Errorf("could not build CRD type: %w", err)
 		}
 
+		if version == "" {
+			version = versionedCRD.Version.Name
+		}
+		if group == "" {
+			group = crdSchema.Spec.Group
+		}
+		if version != versionedCRD.Version.Name || group != crdSchema.Spec.Group {
+			return nil, fmt.Errorf("YAML input should only contain kinds for %s/%s but got %s/%s",
+				group, version, versionedCRD.Version.Name, crdSchema.Spec.Group)
+		}
 		renderReq := render.CRDRenderRequest{
 			Request:  *req,
 			Filename: crd.Kind2Filename(versionedCRD.Kind),
+			Group:    crdSchema.Spec.Group,
 			Version:  versionedCRD.Version.Name,
 			Kind:     versionedCRD.Kind,
+			Resource: crdSchema.Spec.Names.Plural,
 			Type:     goCRD,
 		}
-		if err := render.Default.RenderCRD(&renderReq); err != nil {
-			return nil, fmt.Errorf("failed to generate CRD code: %w", err)
-		}
-		generated = true
-		gvr := fmt.Sprintf("%s/%s/%s",
-			crdSchema.Spec.Group, versionedCRD.Version.Name, crdSchema.Spec.Names.Plural)
-		gvr = strings.TrimPrefix(gvr, "/")
-		generatedGVRs = append(generatedGVRs, gvr)
+		renderRequests = append(renderRequests, renderReq)
 	}
 }
 

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -69,6 +69,23 @@ func TestGenerateFromCRDs(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMixedGroupVersion(t *testing.T) {
+	buffers := make(map[string]*bytes.Buffer)
+
+	in, err := samples.Open("samples/different-gv.yaml")
+	require.NoError(t, err)
+	req := gotype.Request{
+		CodeWriterFn: BufferForCRD(buffers),
+		TypeDict:     gotype.NewTypeDict(nil, preloadedTypes()...),
+		CoreConfig: config.CoreConfig{
+			Version:  crd.FirstVersion,
+			SkipList: disabledKinds,
+		},
+	}
+	want := "YAML input should only contain kinds for atlas.generated.mongodb.com/v2"
+	require.ErrorContains(t, Generate(&req, in), want)
+}
+
 func TestRefs(t *testing.T) {
 	buffers := make(map[string]*bytes.Buffer)
 

--- a/pkg/crd2go/samples/different-gv.yaml
+++ b/pkg/crd2go/samples/different-gv.yaml
@@ -1,0 +1,240 @@
+# Copyright 2025 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: resources.atlas.generated.mongodb.com
+spec:
+  group: atlas.generated.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: Resource
+    listKind: ResourceList
+    plural: resources
+    shortNames:
+    - ar
+    singular: resource
+  scope: Namespaced
+  versions:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: A resource
+        properties:
+          spec:
+            description: Some resource
+            properties:
+              v0:
+                description: The spec of the resource for version v0.
+                properties:
+                  entry:
+                    description: The entry fields of the resource spec.
+                    properties:
+                      name:
+                        description: Human-readable label that identifies the resource.
+                        type: string
+                      dummy:
+                        description: A dummy field, as this is just a dummy test.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  parameters:
+                    description: The parameter fields of resource spec.
+                    properties:
+                      # --- FIX: Changed to lowercase 'id' and 'type: integer' ---
+                      id:
+                        description: Fake resource ID.
+                        type: integer
+                    required:
+                    - id
+                    type: object
+                required:
+                - entry
+                - parameters
+                type: object
+            required:
+            - v0
+            type: object
+          status:
+            description: Most recently observed read-only status of the resource.
+            properties:
+              # --- FIX: Moved 'created' to the top level of status.properties ---
+              created:
+                description: Date and time when resource was created.
+                type: string
+              conditions:
+                description: Represents the latest available observations of a resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+                      type: integer
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: resources.ea.generated.mongodb.com
+spec:
+  group: ea.generated.mongodb.com
+  names:
+    categories:
+    - ea
+    kind: Resource
+    listKind: ResourceList
+    plural: resources
+    shortNames:
+    - er
+    singular: resource
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: A resource
+        properties:
+          spec:
+            description: Some resource
+            properties:
+              v0:
+                description: The spec of the resource for version v0.
+                properties:
+                  entry:
+                    description: The entry fields of the resource spec.
+                    properties:
+                      name:
+                        description: Human-readable label that identifies the resource.
+                        type: string
+                      dummy:
+                        description: A dummy field, as this is just a dummy test.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  parameters:
+                    description: The parameter fields of resource spec.
+                    properties:
+                      # --- FIX: Changed to lowercase 'id' and 'type: integer' ---
+                      id:
+                        description: Fake resource ID.
+                        type: integer
+                    required:
+                    - id
+                    type: object
+                required:
+                - entry
+                - parameters
+                type: object
+            required:
+            - v0
+            type: object
+          status:
+            description: Most recently observed read-only status of the resource.
+            properties:
+              # --- FIX: Moved 'created' to the top level of status.properties ---
+              created:
+                description: Date and time when resource was created.
+                type: string
+              conditions:
+                description: Represents the latest available observations of a resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+                      type: integer
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1


### PR DESCRIPTION
The CRD2Go assumes the YAML input contains Kinds from a single Group and Version combo. Of course, this might not be always true, so generation should fail if that assumption is not met.

I plan a follow up that adds a new CLI parameters to pre-select an explicit Group Version to generate, skipping all the rest YAML inputs that do not match without erroring out.
