### PR TITLE
Support GetConditions as a plugin

### DIFF
--- a/crd2go.yaml
+++ b/crd2go.yaml
@@ -41,6 +41,10 @@ imports:
     alias: k8s
     path: github.com/crd2go/crd2go/k8s
 
+# plugins customize what extra Go code gets generated on top of the CRD types
+plugins:
+  - name: get-conditions
+
 # deepCopy controls the integration with controller-gen to generate deep copy code
 deepCopy:
   generate: auto

--- a/internal/plugins/getconditions.go
+++ b/internal/plugins/getconditions.go
@@ -1,0 +1,75 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/dave/jennifer/jen"
+)
+
+const (
+	GetConditionsPlugin = "get-conditions"
+)
+
+type GetConditions struct {
+}
+
+func (*GetConditions) Name() string {
+	return GetConditionsPlugin
+}
+
+func (*GetConditions) Process(cr *CodegenRequest) error {
+	shortName := shorten(cr.Type.Name)
+	f := cr.File
+	f.Line()
+	f.Comment(fmt.Sprintf("GetConditions for %s", cr.Type.Name))
+	f.Func().Params(
+		jen.Id(shortName).Op("*").Id(cr.Type.Name),
+	).Id("GetConditions").Params().Index().Qual("k8s.io/apimachinery/pkg/apis/meta/v1", "Condition").Block(
+
+		jen.If(jen.Id(shortName).Dot("Status").Dot("Conditions").Op("==").Nil()).Block(
+			jen.Return(jen.Nil()),
+		),
+
+		jen.Return(jen.Op("*").Id(shortName).Dot("Status").Dot("Conditions")),
+	)
+	return nil
+}
+
+func shorten(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+
+	runes := []rune(s)
+	lastLower := false
+	for i, r := range runes {
+		if i == 0 {
+			sb.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		if unicode.IsUpper(r) && lastLower {
+			sb.WriteRune(unicode.ToLower(r))
+			lastLower = false
+		} else {
+			lastLower = true
+		}
+	}
+	return sb.String()
+}

--- a/internal/plugins/getconditions_test.go
+++ b/internal/plugins/getconditions_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crd2go/crd2go/internal/gotype"
+	"github.com/crd2go/crd2go/internal/plugins"
+)
+
+func TestGetConditionsProcess(t *testing.T) {
+	tests := []struct {
+		title         string
+		inputTypeName string
+		wants         []string // Using a slice allows checking multiple parts of the output
+		wantErr       string
+	}{
+		{
+			title:         "Valid Input SampleResource",
+			inputTypeName: "SampleResource",
+			wants: []string{
+				// Check for the comment
+				"// GetConditions for SampleResource",
+				// Check for the function body
+				`func (sr *SampleResource) GetConditions() []metav1.Condition {
+	if sr.Status.Conditions == nil {
+		return nil
+	}
+	return *sr.Status.Conditions
+}`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			f := jen.NewFile("main")
+			f.ImportAlias("k8s.io/apimachinery/pkg/apis/meta/v1", "metav1")
+
+			req := &plugins.CodegenRequest{
+				Type: &gotype.GoType{Name: tc.inputTypeName},
+				File: f,
+			}
+
+			processor := &plugins.GetConditions{}
+			err := processor.Process(req)
+
+			if tc.wantErr != "" {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				buf := &bytes.Buffer{}
+				err = f.Render(buf)
+				require.NoError(t, err)
+				generatedCode := buf.String()
+				for _, want := range tc.wants {
+					assert.Contains(t, generatedCode, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -1,0 +1,55 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/dave/jennifer/jen"
+
+	"github.com/crd2go/crd2go/internal/gotype"
+	"github.com/crd2go/crd2go/pkg/config"
+)
+
+type CodegenRequest struct {
+	Type *gotype.GoType
+	File *jen.File
+}
+
+type Plugin interface {
+	Name() string
+	Process(cgr *CodegenRequest) error
+}
+
+type PluginBuilderFunc func(config.Plugin) Plugin
+
+var codegenPlugins = map[string]PluginBuilderFunc{
+	GetConditionsPlugin: func(config.Plugin) Plugin {
+		return &GetConditions{}
+	},
+}
+
+func CodegenPlugins(configs []config.Plugin) ([]Plugin, error) {
+	plugins := []Plugin{}
+	for _, cfg := range configs {
+		builder, ok := codegenPlugins[cfg.Name]
+		if !ok {
+			return nil, fmt.Errorf("%q is not a registered plugin", cfg.Name)
+		}
+		plugin := builder(cfg)
+		plugins = append(plugins, plugin)
+	}
+	return plugins, nil
+}

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crd2go/crd2go/internal/plugins"
+	"github.com/crd2go/crd2go/pkg/config"
+)
+
+func TestCodegenPlugins(t *testing.T) {
+	tests := []struct {
+		title   string
+		configs []config.Plugin
+		want    []string
+		wantErr string
+	}{
+		{
+			title:   "Empty Config",
+			configs: []config.Plugin{},
+			want:    []string{},
+		},
+		{
+			title:   "Single Valid Plugin",
+			configs: []config.Plugin{{Name: "get-conditions"}},
+			want:    []string{"get-conditions"},
+		},
+		{
+			title:   "Unknown Plugin Error",
+			configs: []config.Plugin{{Name: "non-existent-plugin"}},
+			wantErr: "\"non-existent-plugin\" is not a registered plugin",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			got, err := plugins.CodegenPlugins(tc.configs)
+			if tc.wantErr != "" {
+				require.Nil(t, got)
+				assert.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				names := []string{}
+				for _, plugin := range got {
+					names = append(names, plugin.Name())
+				}
+				require.Equal(t, tc.want, names)
+			}
+		})
+	}
+}

--- a/internal/plugins/shorten_test.go
+++ b/internal/plugins/shorten_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShorten(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"SystemLogRotateConfig", "slrc"},
+		{"MyCustomResource", "mcr"},
+		{"Simple", "s"},
+		{"a", "a"},
+		{"", ""},
+		{"HTTPClient", "htc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := shorten(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/render/jen.go
+++ b/internal/render/jen.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/crd2go/crd2go/internal/checkerr"
 	"github.com/crd2go/crd2go/internal/gotype"
+	"github.com/crd2go/crd2go/internal/plugins"
 )
 
 const (
@@ -64,6 +65,9 @@ func (jr JenRenderer) RenderCRD(req *CRDRenderRequest) error {
 		return fmt.Errorf("failed to generate CRD type for %q: %w", req.Kind, err)
 	}
 	renderCRDListObject(f, req.Kind)
+	if err := renderCodegenPlugins(f, req); err != nil {
+		return fmt.Errorf("failed to render plugins: %w", err)
+	}
 
 	w, err := req.CodeWriterFn(req.Filename, true)
 	if err != nil {
@@ -107,6 +111,24 @@ func renderCRDListObject(f *jen.File, kind string) {
 		jen.Qual(metav1Package, "ListMeta").Tag(map[string]string{"json": "metadata,omitempty"}),
 		jen.Id("Items").Index().Id(kind).Tag(map[string]string{"json": "items"}),
 	)
+}
+
+// renderCodegenPlugins appends code generation from optional plugins per CRD
+func renderCodegenPlugins(f *jen.File, req *CRDRenderRequest) error {
+	codeGenPlugins, err := plugins.CodegenPlugins(req.Plugins)
+	if err != nil {
+		return fmt.Errorf("failed to enumerate codegen plugins: %w", err)
+	}
+	pluginRequest := plugins.CodegenRequest{
+		File: f,
+		Type: req.Type,
+	}
+	for _, plugin := range codeGenPlugins {
+		if err := plugin.Process(&pluginRequest); err != nil {
+			return fmt.Errorf("failed to process plugin %q: %w", plugin.Name(), err)
+		}
+	}
+	return nil
 }
 
 func renderDocFile(req *gotype.Request, group, version string) error {

--- a/internal/testdata/v1/backupcompliancepolicy.go
+++ b/internal/testdata/v1/backupcompliancepolicy.go
@@ -159,3 +159,11 @@ type BackupCompliancePolicyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []BackupCompliancePolicy `json:"items"`
 }
+
+// GetConditions for BackupCompliancePolicy
+func (bcp *BackupCompliancePolicy) GetConditions() []metav1.Condition {
+	if bcp.Status.Conditions == nil {
+		return nil
+	}
+	return *bcp.Status.Conditions
+}

--- a/internal/testdata/v1/backupschedule.go
+++ b/internal/testdata/v1/backupschedule.go
@@ -197,3 +197,11 @@ type BackupScheduleList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []BackupSchedule `json:"items"`
 }
+
+// GetConditions for BackupSchedule
+func (bs *BackupSchedule) GetConditions() []metav1.Condition {
+	if bs.Status.Conditions == nil {
+		return nil
+	}
+	return *bs.Status.Conditions
+}

--- a/internal/testdata/v1/cluster.go
+++ b/internal/testdata/v1/cluster.go
@@ -714,3 +714,11 @@ type ClusterList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Cluster `json:"items"`
 }
+
+// GetConditions for Cluster
+func (c *Cluster) GetConditions() []metav1.Condition {
+	if c.Status.Conditions == nil {
+		return nil
+	}
+	return *c.Status.Conditions
+}

--- a/internal/testdata/v1/customrole.go
+++ b/internal/testdata/v1/customrole.go
@@ -111,3 +111,11 @@ type CustomRoleList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []CustomRole `json:"items"`
 }
+
+// GetConditions for CustomRole
+func (cr *CustomRole) GetConditions() []metav1.Condition {
+	if cr.Status.Conditions == nil {
+		return nil
+	}
+	return *cr.Status.Conditions
+}

--- a/internal/testdata/v1/databaseuser.go
+++ b/internal/testdata/v1/databaseuser.go
@@ -164,3 +164,11 @@ type DatabaseUserList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DatabaseUser `json:"items"`
 }
+
+// GetConditions for DatabaseUser
+func (du *DatabaseUser) GetConditions() []metav1.Condition {
+	if du.Status.Conditions == nil {
+		return nil
+	}
+	return *du.Status.Conditions
+}

--- a/internal/testdata/v1/datafederation.go
+++ b/internal/testdata/v1/datafederation.go
@@ -369,3 +369,11 @@ type DataFederationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DataFederation `json:"items"`
 }
+
+// GetConditions for DataFederation
+func (df *DataFederation) GetConditions() []metav1.Condition {
+	if df.Status.Conditions == nil {
+		return nil
+	}
+	return *df.Status.Conditions
+}

--- a/internal/testdata/v1/flexcluster.go
+++ b/internal/testdata/v1/flexcluster.go
@@ -168,3 +168,11 @@ type FlexClusterList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []FlexCluster `json:"items"`
 }
+
+// GetConditions for FlexCluster
+func (fc *FlexCluster) GetConditions() []metav1.Condition {
+	if fc.Status.Conditions == nil {
+		return nil
+	}
+	return *fc.Status.Conditions
+}

--- a/internal/testdata/v1/group.go
+++ b/internal/testdata/v1/group.go
@@ -108,3 +108,11 @@ type GroupList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Group `json:"items"`
 }
+
+// GetConditions for Group
+func (g *Group) GetConditions() []metav1.Condition {
+	if g.Status.Conditions == nil {
+		return nil
+	}
+	return *g.Status.Conditions
+}

--- a/internal/testdata/v1/groupalertsconfig.go
+++ b/internal/testdata/v1/groupalertsconfig.go
@@ -401,3 +401,11 @@ type GroupAlertsConfigList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []GroupAlertsConfig `json:"items"`
 }
+
+// GetConditions for GroupAlertsConfig
+func (gac *GroupAlertsConfig) GetConditions() []metav1.Condition {
+	if gac.Status.Conditions == nil {
+		return nil
+	}
+	return *gac.Status.Conditions
+}

--- a/internal/testdata/v1/networkpeeringconnection.go
+++ b/internal/testdata/v1/networkpeeringconnection.go
@@ -150,3 +150,11 @@ type NetworkPeeringConnectionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []NetworkPeeringConnection `json:"items"`
 }
+
+// GetConditions for NetworkPeeringConnection
+func (npc *NetworkPeeringConnection) GetConditions() []metav1.Condition {
+	if npc.Status.Conditions == nil {
+		return nil
+	}
+	return *npc.Status.Conditions
+}

--- a/internal/testdata/v1/networkpermissionentries.go
+++ b/internal/testdata/v1/networkpermissionentries.go
@@ -108,3 +108,11 @@ type NetworkPermissionEntriesList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []NetworkPermissionEntries `json:"items"`
 }
+
+// GetConditions for NetworkPermissionEntries
+func (npe *NetworkPermissionEntries) GetConditions() []metav1.Condition {
+	if npe.Status.Conditions == nil {
+		return nil
+	}
+	return *npe.Status.Conditions
+}

--- a/internal/testdata/v1/organization.go
+++ b/internal/testdata/v1/organization.go
@@ -117,3 +117,11 @@ type OrganizationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Organization `json:"items"`
 }
+
+// GetConditions for Organization
+func (o *Organization) GetConditions() []metav1.Condition {
+	if o.Status.Conditions == nil {
+		return nil
+	}
+	return *o.Status.Conditions
+}

--- a/internal/testdata/v1/organizationsetting.go
+++ b/internal/testdata/v1/organizationsetting.go
@@ -95,3 +95,11 @@ type OrganizationSettingList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []OrganizationSetting `json:"items"`
 }
+
+// GetConditions for OrganizationSetting
+func (os *OrganizationSetting) GetConditions() []metav1.Condition {
+	if os.Status.Conditions == nil {
+		return nil
+	}
+	return *os.Status.Conditions
+}

--- a/internal/testdata/v1/sampledataset.go
+++ b/internal/testdata/v1/sampledataset.go
@@ -90,3 +90,11 @@ type SampleDatasetList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []SampleDataset `json:"items"`
 }
+
+// GetConditions for SampleDataset
+func (sd *SampleDataset) GetConditions() []metav1.Condition {
+	if sd.Status.Conditions == nil {
+		return nil
+	}
+	return *sd.Status.Conditions
+}

--- a/internal/testdata/v1/searchindex.go
+++ b/internal/testdata/v1/searchindex.go
@@ -329,3 +329,11 @@ type SearchIndexList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []SearchIndex `json:"items"`
 }
+
+// GetConditions for SearchIndex
+func (si *SearchIndex) GetConditions() []metav1.Condition {
+	if si.Status.Conditions == nil {
+		return nil
+	}
+	return *si.Status.Conditions
+}

--- a/internal/testdata/v1/team.go
+++ b/internal/testdata/v1/team.go
@@ -68,3 +68,11 @@ type TeamList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Team `json:"items"`
 }
+
+// GetConditions for Team
+func (t *Team) GetConditions() []metav1.Condition {
+	if t.Status.Conditions == nil {
+		return nil
+	}
+	return *t.Status.Conditions
+}

--- a/internal/testdata/v1/thirdpartyintegration.go
+++ b/internal/testdata/v1/thirdpartyintegration.go
@@ -267,3 +267,11 @@ type ThirdPartyIntegrationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ThirdPartyIntegration `json:"items"`
 }
+
+// GetConditions for ThirdPartyIntegration
+func (tpi *ThirdPartyIntegration) GetConditions() []metav1.Condition {
+	if tpi.Status.Conditions == nil {
+		return nil
+	}
+	return *tpi.Status.Conditions
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,8 +63,14 @@ type CoreConfig struct {
 	SkipList     []string             `yaml:"skipList"`
 	Renames      map[string]string    `yaml:"renames"`
 	Imports      []ImportedTypeConfig `yaml:"imports"`
+	Plugins      []Plugin             `yaml:"plugins"`
 	DeepCopy     DeepCopy             `yaml:"deepCopy"`
 	GroupVersion string               `yaml:"-"`
+}
+
+// Plugin represents a named plugin code that can be optionally invoked
+type Plugin struct {
+	Name string `yaml:"name"`
 }
 
 type DeepCopy struct {

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -54,6 +54,11 @@ func TestGenerateFromCRDs(t *testing.T) {
 		CoreConfig: config.CoreConfig{
 			Version:  crd.FirstVersion,
 			SkipList: disabledKinds,
+			Plugins: []config.Plugin{
+				{
+					Name: "get-conditions",
+				},
+			},
 		},
 	}
 	require.NoError(t, Generate(&req, in))
@@ -85,8 +90,7 @@ func TestGenerateFromMixedGroupVersion(t *testing.T) {
 func TestGenerateSelectedGroupVersion(t *testing.T) {
 	buffers := make(map[string]*bytes.Buffer)
 
-	in, err := samples.Open("samples/different-gv.yaml")
-	require.NoError(t, err)
+	in := bytes.NewBuffer(testdata.DifferentGVYAML)
 	req := gotype.Request{
 		CodeWriterFn: BufferForCRD(buffers),
 		TypeDict:     gotype.NewTypeDict(nil, preloadedTypes()...),
@@ -98,11 +102,8 @@ func TestGenerateSelectedGroupVersion(t *testing.T) {
 	}
 	require.NoError(t, Generate(&req, in))
 	assert.Len(t, buffers, 3)
-	f, err := samples.Open("samples/resource.go.generated")
-	require.NoError(t, err)
-	want, err := io.ReadAll(f)
-	require.NoError(t, err)
-	assert.Equal(t, string(want), buffers["resource.go"].String())
+	want := testdata.ResourceGoGenerated
+	assert.Equal(t, want, buffers["resource.go"].String())
 }
 
 func TestRefs(t *testing.T) {


### PR DESCRIPTION
Adds a `get-conditions` plugin that allows to extract the conditions list from the status.

Appends code to the CRD type such as:
```go
// GetConditions for SampleResource
func (sr *SampleResource) GetConditions() []metav1.Condition {
	if sr.Status.Conditions == nil {
		return nil
	}
	return *sr.Status.Conditions
}
```