### PR TITLE
Security bump to Go 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,6 @@ jobs:
         go-version: '1.25'
 
     - name: CI checks
+      env:
+        GOTOOLCHAIN: auto
       run: go tool mage ci

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crd2go/crd2go
 
-go 1.25.3
+go 1.25.8
 
 require (
 	github.com/dave/jennifer v1.7.1


### PR DESCRIPTION
Bump Go to 1.25.8 for security issues:
https://pkg.go.dev/vuln/GO-2026-4599
https://pkg.go.dev/vuln/GO-2026-4600
https://pkg.go.dev/vuln/GO-2026-4601
https://pkg.go.dev/vuln/GO-2026-4602
https://pkg.go.dev/vuln/GO-2026-4603