### PR TITLE
Add go-client generation support via plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,69 @@ Extra configuration settings:
   - *applyConfiguration.generate* (`true`/`false`, defaults to `false`). When `true`, crd2go adds `+kubebuilder:ac:generate=true` to `doc.go` and a `SchemeGroupVersion` alias to `groupversion_info.go`.
   - *applyConfiguration.outputPackage* sets the `+kubebuilder:ac:output:package` marker value.
 
+### Plugins
+
+Optional plugins extend the generated code on a per-CRD basis. Enable them in `crd2go.yaml` under `plugins`:
+
+```yaml
+plugins:
+  - name: <plugin-name>
+    options:            # optional key/value pairs, plugin-specific
+      key: value
+```
+
+#### `get-conditions`
+
+Generates a `GetConditions() []metav1.Condition` method on the root kind type, for use with condition-aware controllers. The CRD's status schema must contain a `conditions` field of the standard `metav1.Condition` array type.
+
+```yaml
+plugins:
+  - name: get-conditions
+```
+
+No options are supported for this plugin.
+
+#### `gen-client`
+
+Adds [`+genclient`](https://github.com/kubernetes/code-generator) markers before the root kind type definition, so that `k8s.io/code-generator`'s `client-gen` tool generates a typed client for the resource.
+
+```yaml
+plugins:
+  - name: gen-client
+```
+
+The following option is supported:
+
+| Option | Values | Default | Description |
+|---|---|---|---|
+| `nonNamespaced` | `"true"` / `"false"` | `"false"` | Adds `+genclient:nonNamespaced` for cluster-scoped resources. |
+
+Example for a cluster-scoped resource:
+
+```yaml
+plugins:
+  - name: gen-client
+    options:
+      nonNamespaced: "true"
+```
+
+With `nonNamespaced: "true"` the generated file will contain:
+
+```go
+// +genclient
+// +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+type MyResource struct { ... }
+```
+
+Without the option:
+
+```go
+// +genclient
+// +kubebuilder:object:root=true
+type MyResource struct { ... }
+```
+
 ### Type naming and schema evolution
 
 crd2go picks Go type names from CRD shapes and resolves collisions (for example by prepending path segments) so output always type-checks. **Those names are not guaranteed to stay the same when inputs change.** Adding or renaming fields, introducing new kinds, or loading more CRDs into the same pass can create new collisions or change resolution order, so **existing generated type identifiers may rename** even when their underlying schema concept did not change.

--- a/internal/plugins/genclient.go
+++ b/internal/plugins/genclient.go
@@ -1,0 +1,53 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"github.com/dave/jennifer/jen"
+
+	"github.com/crd2go/crd2go/pkg/config"
+)
+
+const (
+	GenClientPlugin = "gen-client"
+)
+
+type GenClient struct {
+	nonNamespaced bool
+}
+
+func newGenClientPlugin(cfg config.Plugin) Plugin {
+	return &GenClient{
+		nonNamespaced: cfg.Options["nonNamespaced"] == "true",
+	}
+}
+
+func (*GenClient) Name() string {
+	return GenClientPlugin
+}
+
+// Annotate adds +genclient markers before the top-level kind type definition.
+func (gc *GenClient) Annotate(f *jen.File, _ string) error {
+	f.Comment("+genclient")
+	if gc.nonNamespaced {
+		f.Comment("+genclient:nonNamespaced")
+	}
+	return nil
+}
+
+// Process is a no-op; gen-client only adds annotations, not post-type code.
+func (*GenClient) Process(_ *CodegenRequest) error {
+	return nil
+}

--- a/internal/plugins/genclient_test.go
+++ b/internal/plugins/genclient_test.go
@@ -60,11 +60,8 @@ func TestGenClientAnnotate(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, pluginList, 1)
 
-			annotator, ok := pluginList[0].(plugins.Annotator)
-			require.True(t, ok, "gen-client plugin must implement Annotator")
-
 			f := jen.NewFile("v1")
-			require.NoError(t, annotator.Annotate(f, "MyKind"))
+			require.NoError(t, pluginList[0].Annotate(f, "MyKind"))
 
 			buf := &bytes.Buffer{}
 			require.NoError(t, f.Render(buf))
@@ -101,9 +98,7 @@ func TestGenClientAnnotateIsBeforeType(t *testing.T) {
 	pluginList, err := plugins.CodegenPlugins([]config.Plugin{{Name: "gen-client"}})
 	require.NoError(t, err)
 
-	annotator, ok := pluginList[0].(plugins.Annotator)
-	require.True(t, ok)
-	require.NoError(t, annotator.Annotate(f, "MyKind"))
+	require.NoError(t, pluginList[0].Annotate(f, "MyKind"))
 
 	f.Type().Id("MyKind").Struct()
 

--- a/internal/plugins/genclient_test.go
+++ b/internal/plugins/genclient_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crd2go/crd2go/internal/plugins"
+	"github.com/crd2go/crd2go/pkg/config"
+)
+
+func TestGenClientAnnotate(t *testing.T) {
+	tests := []struct {
+		title   string
+		options map[string]string
+		wants   []string
+		notwant []string
+	}{
+		{
+			title:   "no options produces +genclient only",
+			options: nil,
+			wants:   []string{"// +genclient"},
+			notwant: []string{"// +genclient:nonNamespaced"},
+		},
+		{
+			title:   "nonNamespaced false produces +genclient only",
+			options: map[string]string{"nonNamespaced": "false"},
+			wants:   []string{"// +genclient"},
+			notwant: []string{"// +genclient:nonNamespaced"},
+		},
+		{
+			title:   "nonNamespaced true produces both markers",
+			options: map[string]string{"nonNamespaced": "true"},
+			wants:   []string{"// +genclient", "// +genclient:nonNamespaced"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			pluginList, err := plugins.CodegenPlugins([]config.Plugin{
+				{Name: "gen-client", Options: tc.options},
+			})
+			require.NoError(t, err)
+			require.Len(t, pluginList, 1)
+
+			annotator, ok := pluginList[0].(plugins.Annotator)
+			require.True(t, ok, "gen-client plugin must implement Annotator")
+
+			f := jen.NewFile("v1")
+			require.NoError(t, annotator.Annotate(f, "MyKind"))
+
+			buf := &bytes.Buffer{}
+			require.NoError(t, f.Render(buf))
+			output := buf.String()
+
+			for _, want := range tc.wants {
+				assert.Contains(t, output, want)
+			}
+			for _, notwant := range tc.notwant {
+				assert.NotContains(t, output, notwant)
+			}
+		})
+	}
+}
+
+func TestGenClientProcess(t *testing.T) {
+	pluginList, err := plugins.CodegenPlugins([]config.Plugin{{Name: "gen-client"}})
+	require.NoError(t, err)
+	require.Len(t, pluginList, 1)
+
+	f := jen.NewFile("v1")
+	err = pluginList[0].Process(&plugins.CodegenRequest{File: f})
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, f.Render(buf))
+	assert.NotContains(t, buf.String(), "+genclient", "Process should not add any genclient markers")
+}
+
+func TestGenClientAnnotateIsBeforeType(t *testing.T) {
+	// Verify that when used in a file, the +genclient marker appears before the type definition.
+	f := jen.NewFile("v1")
+
+	pluginList, err := plugins.CodegenPlugins([]config.Plugin{{Name: "gen-client"}})
+	require.NoError(t, err)
+
+	annotator, ok := pluginList[0].(plugins.Annotator)
+	require.True(t, ok)
+	require.NoError(t, annotator.Annotate(f, "MyKind"))
+
+	f.Type().Id("MyKind").Struct()
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, f.Render(buf))
+	output := buf.String()
+
+	genClientPos := bytes.Index(buf.Bytes(), []byte("+genclient"))
+	typePos := bytes.Index(buf.Bytes(), []byte("type MyKind"))
+	assert.Greater(t, typePos, genClientPos, "+genclient marker must appear before the type definition\n%s", output)
+}

--- a/internal/plugins/getconditions.go
+++ b/internal/plugins/getconditions.go
@@ -33,6 +33,10 @@ func (*GetConditions) Name() string {
 	return GetConditionsPlugin
 }
 
+func (*GetConditions) Annotate(_ *jen.File, _ string) error {
+	return nil
+}
+
 func (*GetConditions) Process(cr *CodegenRequest) error {
 	shortName := shorten(cr.Type.Name)
 	f := cr.File

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -31,11 +31,6 @@ type CodegenRequest struct {
 type Plugin interface {
 	Name() string
 	Process(cgr *CodegenRequest) error
-}
-
-// Annotator is an optional interface plugins may implement to add
-// markers/comments before the top-level type definition in a CRD file.
-type Annotator interface {
 	Annotate(f *jen.File, kind string) error
 }
 

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -33,12 +33,19 @@ type Plugin interface {
 	Process(cgr *CodegenRequest) error
 }
 
+// Annotator is an optional interface plugins may implement to add
+// markers/comments before the top-level type definition in a CRD file.
+type Annotator interface {
+	Annotate(f *jen.File, kind string) error
+}
+
 type PluginBuilderFunc func(config.Plugin) Plugin
 
 var codegenPlugins = map[string]PluginBuilderFunc{
 	GetConditionsPlugin: func(config.Plugin) Plugin {
 		return &GetConditions{}
 	},
+	GenClientPlugin: newGenClientPlugin,
 }
 
 func CodegenPlugins(configs []config.Plugin) ([]Plugin, error) {

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -42,6 +42,19 @@ func TestCodegenPlugins(t *testing.T) {
 			want:    []string{"get-conditions"},
 		},
 		{
+			title:   "gen-client plugin",
+			configs: []config.Plugin{{Name: "gen-client"}},
+			want:    []string{"gen-client"},
+		},
+		{
+			title: "multiple plugins",
+			configs: []config.Plugin{
+				{Name: "get-conditions"},
+				{Name: "gen-client"},
+			},
+			want: []string{"get-conditions", "gen-client"},
+		},
+		{
 			title:   "Unknown Plugin Error",
 			configs: []config.Plugin{{Name: "non-existent-plugin"}},
 			wantErr: "\"non-existent-plugin\" is not a registered plugin",

--- a/internal/render/jen.go
+++ b/internal/render/jen.go
@@ -119,7 +119,7 @@ func renderCRDListObject(f *jen.File, kind string) {
 	)
 }
 
-// renderAnnotationPlugins runs plugins that implement Annotator before the type
+// renderAnnotationPlugins runs all plugins' Annotate method before the type
 // definition, allowing them to add markers/comments above the root kind struct.
 func renderAnnotationPlugins(f *jen.File, req *CRDRenderRequest) error {
 	codeGenPlugins, err := plugins.CodegenPlugins(req.Plugins)
@@ -127,11 +127,7 @@ func renderAnnotationPlugins(f *jen.File, req *CRDRenderRequest) error {
 		return fmt.Errorf("failed to enumerate codegen plugins: %w", err)
 	}
 	for _, plugin := range codeGenPlugins {
-		annotator, ok := plugin.(plugins.Annotator)
-		if !ok {
-			continue
-		}
-		if err := annotator.Annotate(f, req.Kind); err != nil {
+		if err := plugin.Annotate(f, req.Kind); err != nil {
 			return fmt.Errorf("failed to annotate with plugin %q: %w", plugin.Name(), err)
 		}
 	}

--- a/internal/render/jen.go
+++ b/internal/render/jen.go
@@ -61,6 +61,9 @@ func (jr JenRenderer) RenderCRD(req *CRDRenderRequest) error {
 	if deepCopyEnabled(&req.Request) {
 		f.Comment("+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object")
 	}
+	if err := renderAnnotationPlugins(f, req); err != nil {
+		return fmt.Errorf("failed to render annotation plugins: %w", err)
+	}
 	f.Comment("+kubebuilder:object:root=true")
 	f.Comment("+kubebuilder:resource").Line()
 
@@ -114,6 +117,25 @@ func renderCRDListObject(f *jen.File, kind string) {
 		jen.Qual(metav1Package, "ListMeta").Tag(map[string]string{"json": "metadata,omitempty"}),
 		jen.Id("Items").Index().Id(kind).Tag(map[string]string{"json": "items"}),
 	)
+}
+
+// renderAnnotationPlugins runs plugins that implement Annotator before the type
+// definition, allowing them to add markers/comments above the root kind struct.
+func renderAnnotationPlugins(f *jen.File, req *CRDRenderRequest) error {
+	codeGenPlugins, err := plugins.CodegenPlugins(req.Plugins)
+	if err != nil {
+		return fmt.Errorf("failed to enumerate codegen plugins: %w", err)
+	}
+	for _, plugin := range codeGenPlugins {
+		annotator, ok := plugin.(plugins.Annotator)
+		if !ok {
+			continue
+		}
+		if err := annotator.Annotate(f, req.Kind); err != nil {
+			return fmt.Errorf("failed to annotate with plugin %q: %w", plugin.Name(), err)
+		}
+	}
+	return nil
 }
 
 // renderCodegenPlugins appends code generation from optional plugins per CRD

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,7 +58,8 @@ type CoreConfig struct {
 
 // Plugin represents a named plugin code that can be optionally invoked
 type Plugin struct {
-	Name string `yaml:"name"`
+	Name    string            `yaml:"name"`
+	Options map[string]string `yaml:"options"`
 }
 
 // DeepCopy controls whether deepcopy markers are emitted in the generated code.

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -207,6 +207,82 @@ func TestGenerateWithDeepCopy(t *testing.T) {
 	}
 }
 
+func TestGenerateWithGenClient(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		plugins               []config.Plugin
+		wantGenClient         bool
+		wantNonNamespaced     bool
+		wantBeforeKubebuilder bool
+	}{
+		{
+			name:          "no gen-client plugin produces no marker",
+			plugins:       []config.Plugin{},
+			wantGenClient: false,
+		},
+		{
+			name:          "gen-client plugin produces +genclient marker",
+			plugins:       []config.Plugin{{Name: "gen-client"}},
+			wantGenClient: true,
+		},
+		{
+			name:              "gen-client nonNamespaced produces both markers",
+			plugins:           []config.Plugin{{Name: "gen-client", Options: map[string]string{"nonNamespaced": "true"}}},
+			wantGenClient:     true,
+			wantNonNamespaced: true,
+		},
+		{
+			name:                  "gen-client marker appears before +kubebuilder:object:root",
+			plugins:               []config.Plugin{{Name: "gen-client"}},
+			wantGenClient:         true,
+			wantBeforeKubebuilder: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buffers := make(map[string]*bytes.Buffer)
+
+			in := bytes.NewBuffer(testdata.CRDsYAML)
+			req := gotype.Request{
+				CodeWriterFn: BufferForCRD(buffers),
+				TypeDict:     gotype.NewTypeDict(nil, preloadedTypes()),
+				CoreConfig: config.CoreConfig{
+					Version:  crd.FirstVersion,
+					SkipList: disabledKinds,
+					Plugins:  tc.plugins,
+				},
+			}
+			require.NoError(t, Generate(&req, in))
+
+			// Check a CRD file (skip doc.go and groupversion_info.go)
+			for name, buf := range buffers {
+				if name == "doc.go" || name == "groupversion_info.go" {
+					continue
+				}
+				content := buf.String()
+
+				if tc.wantGenClient {
+					assert.Contains(t, content, "// +genclient", "expected +genclient in %s", name)
+				} else {
+					assert.NotContains(t, content, "// +genclient", "unexpected +genclient in %s", name)
+				}
+
+				if tc.wantNonNamespaced {
+					assert.Contains(t, content, "// +genclient:nonNamespaced", "expected +genclient:nonNamespaced in %s", name)
+				} else {
+					assert.NotContains(t, content, "// +genclient:nonNamespaced", "unexpected +genclient:nonNamespaced in %s", name)
+				}
+
+				if tc.wantBeforeKubebuilder {
+					genClientPos := bytes.Index(buf.Bytes(), []byte("+genclient"))
+					kubebuilderPos := bytes.Index(buf.Bytes(), []byte("+kubebuilder:object:root"))
+					assert.Greater(t, kubebuilderPos, genClientPos, "+genclient must appear before +kubebuilder:object:root in %s", name)
+				}
+				break
+			}
+		})
+	}
+}
+
 func TestGenerateWithApplyConfiguration(t *testing.T) {
 	for _, tc := range []struct {
 		name                   string
@@ -373,6 +449,20 @@ imports: []`,
 				CoreConfig: config.CoreConfig{
 					ApplyConfiguration: config.ApplyConfiguration{
 						Generate: false,
+					},
+				},
+			},
+		},
+		{
+			name: "gen-client plugin with options",
+			input: `plugins:
+  - name: gen-client
+    options:
+      nonNamespaced: "true"`,
+			want: &config.Config{
+				CoreConfig: config.CoreConfig{
+					Plugins: []config.Plugin{
+						{Name: "gen-client", Options: map[string]string{"nonNamespaced": "true"}},
 					},
 				},
 			},


### PR DESCRIPTION
Solves #48 supporting the optional addition of +genclient annotations as a plugin