### PR TITLE
Smarter naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,8 @@ Committed trees such as **`internal/testdata/v1`** are different: they are meant
 
 crd2go assigns each generated struct a Go name from the CRD shape. Types that are structurally identical share one name; among the candidate spellings, the shortest wins.
 
-If two different shapes would use the same name, the generator prepends pieces of the field path from the nested type up toward the root—one segment per pass—until every name is unique. That rule is deterministic and always produces valid Go, but it does not minimize name length in every case (shared path segments can add extra prefixes before types diverge). User **`renames`** and **`imports`** still override or replace generated names where you need something explicit.
+If two different shapes would use the same name, the generator prepends ancestor path segments (immediate parent first, then toward the root) until every name is unique. Path positions where all conflicting candidates share the same segment are skipped, since they cannot help distinguish the names — producing shorter results than blindly accumulating every ancestor.
+
+For example, given two conflicting types at paths `SomeType.SomeTypeSpec.SubType.Leaf` and `SomeOtherType.SomeOtherTypeSpec.SubType.Leaf`, the shared `SubType` segment is skipped, and the first differing ancestor (`SomeTypeSpec` / `SomeOtherTypeSpec`) is used, yielding `SomeTypeSpecLeaf` and `SomeOtherTypeSpecLeaf` instead of `SomeTypeSpecSubTypeLeaf` and `SomeOtherTypeSpecSubTypeLeaf`.
+
+The algorithm is deterministic and always produces valid Go. User **`renames`** and **`imports`** still override or replace generated names where you need something explicit.

--- a/crd2go.yaml
+++ b/crd2go.yaml
@@ -25,6 +25,13 @@ skipList: []
 # list of reserved Type names to avoid using
 reserved: []
 
+# neverSkipSegments lists regex patterns for path segments that must never be skipped
+# during name conflict resolution, even when all conflicting candidates share the same
+# segment value. The canonical use case is API version segments (e.g. V20250312) which
+# should be preserved in type names for future naming stability.
+neverSkipSegments:
+  - "V[0-9]+"
+
 # renames to apply before type name evaluation and de-duplication 
 # a matching key is replaced by the given value
 renames:

--- a/internal/gotype/naming.go
+++ b/internal/gotype/naming.go
@@ -96,7 +96,9 @@ type NameEngine interface {
 	// Names are unique and deterministic. Among types with the same structure (aliases), the
 	// shortest name wins. When different types would share the same Go identifier, ancestor
 	// path segments are prepended (immediate parent first, then toward the root) until names
-	// differ; those disambiguated names are not guaranteed to be the shortest possible.
+	// differ. Positions where every conflicting candidate shares the same segment are skipped,
+	// since they cannot help disambiguate — producing shorter names than the legacy behaviour
+	// of blindly accumulating every ancestor.
 	NamedRoots() ([]*GoType, error)
 
 	// Has returns true if a type with the same structure (hash) was registered.
@@ -276,8 +278,10 @@ func (n *nameEngine) solveConflictingNames(candidateTypes []typeInfo) error {
 	return n.prependPaths(candidateTypes)
 }
 
-// prependPaths resolves name conflicts by prepending ancestor path segments to each
-// candidate's name until all names are unique. A pinned candidate, if any, is skipped
+// prependPaths resolves name conflicts by prepending ancestor path segments
+// (immediate parent first, then toward the root) until all names are unique.
+// Positions where every candidate shares the same segment value are skipped,
+// since they cannot help disambiguate. A pinned candidate, if any, is skipped
 // so its name is never modified.
 func (n *nameEngine) prependPaths(candidateTypes []typeInfo) error {
 	frozenIdx := n.findPinnedCandidate(candidateTypes)
@@ -287,13 +291,26 @@ func (n *nameEngine) prependPaths(candidateTypes []typeInfo) error {
 			maxPathLen = len(c.path)
 		}
 	}
-	// Prepend ancestor path segments (root first). Skip the last segment since it often equals the type name.
 	maxRounds := maxPathLen
 	if maxRounds > 0 {
 		maxRounds--
 	}
-	// Prepend from immediate parent toward root (leaf-to-root) to match legacy behavior.
 	for round := 1; round <= maxRounds; round++ {
+		// Check whether every candidate has the same segment at this position.
+		// If so, prepending it cannot help disambiguate — skip this round.
+		vals := make(map[string]bool, len(candidateTypes))
+		for _, c := range candidateTypes {
+			idx := len(c.path) - 1 - round
+			seg := ""
+			if idx >= 0 {
+				seg = c.path[idx]
+			}
+			vals[seg] = true
+		}
+		if len(vals) <= 1 {
+			continue
+		}
+
 		for i := range candidateTypes {
 			if i == frozenIdx {
 				continue

--- a/internal/gotype/naming.go
+++ b/internal/gotype/naming.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -115,13 +116,14 @@ type typeInfo struct {
 }
 
 type nameEngine struct {
-	byHash           map[string][]typeInfo
-	hashCache        map[*GoType]string
-	roots            []*GoType
-	byName           map[string]*GoType
-	existingNames    map[string]string // typename → file path
-	pinnedPaths      map[string]bool   // dot-joined paths that must not be renamed
-	pendingConflicts []ExistingNameConflict
+	byHash            map[string][]typeInfo
+	hashCache         map[*GoType]string
+	roots             []*GoType
+	byName            map[string]*GoType
+	existingNames     map[string]string // typename → file path
+	pinnedPaths       map[string]bool   // dot-joined paths that must not be renamed
+	neverSkipSegments []*regexp.Regexp  // segments matching these patterns are never skipped
+	pendingConflicts  []ExistingNameConflict
 }
 
 func NewNameEngine() NameEngine {
@@ -297,7 +299,9 @@ func (n *nameEngine) prependPaths(candidateTypes []typeInfo) error {
 	}
 	for round := 1; round <= maxRounds; round++ {
 		// Check whether every candidate has the same segment at this position.
-		// If so, prepending it cannot help disambiguate — skip this round.
+		// If so, prepending it cannot help disambiguate — skip this round,
+		// unless the shared segment matches a neverSkipSegments pattern, in
+		// which case we still prepend it for future naming stability.
 		vals := make(map[string]bool, len(candidateTypes))
 		for _, c := range candidateTypes {
 			idx := len(c.path) - 1 - round
@@ -308,7 +312,13 @@ func (n *nameEngine) prependPaths(candidateTypes []typeInfo) error {
 			vals[seg] = true
 		}
 		if len(vals) <= 1 {
-			continue
+			var sharedSeg string
+			for s := range vals {
+				sharedSeg = s
+			}
+			if !n.matchesNeverSkip(sharedSeg) {
+				continue
+			}
 		}
 
 		for i := range candidateTypes {
@@ -344,6 +354,15 @@ func (n *nameEngine) findPinnedCandidate(candidates []typeInfo) int {
 		}
 	}
 	return -1
+}
+
+func (n *nameEngine) matchesNeverSkip(seg string) bool {
+	for _, re := range n.neverSkipSegments {
+		if re.MatchString(seg) {
+			return true
+		}
+	}
+	return false
 }
 
 func (n *nameEngine) isExistingNameConflict(candidateTypes []typeInfo) bool {

--- a/internal/gotype/naming_test.go
+++ b/internal/gotype/naming_test.go
@@ -16,6 +16,7 @@
 package gotype
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -182,12 +183,13 @@ func TestUniqueTypes_sameHashDistinctPointers(t *testing.T) {
 
 func TestNameEngine(t *testing.T) {
 	tests := []struct {
-		name          string
-		regsFn        func() []nameEngineReg
-		setupFn       func(t *testing.T) (existingNames map[string]string, pinnedPaths map[string]bool)
-		want          []string
-		wantErr       bool
-		wantConflicts []ExistingNameConflict
+		name              string
+		regsFn            func() []nameEngineReg
+		setupFn           func(t *testing.T) (existingNames map[string]string, pinnedPaths map[string]bool)
+		neverSkipPatterns []string
+		want              []string
+		wantErr           bool
+		wantConflicts     []ExistingNameConflict
 	}{
 		{
 			name: "single root",
@@ -402,6 +404,26 @@ func TestNameEngine(t *testing.T) {
 			want: []string{"Deep", "FieldName", "Some", "SomeFieldName"},
 		},
 		{
+			// OrgSpec.V20250312.Entry vs TeamSpec.V20250312.Entry:
+			// Round 1 (V20250312) is shared but matches neverSkipSegments → preserve it.
+			// After round 1 both names are V20250312Entry (still conflicting).
+			// Round 2 (OrgSpec/TeamSpec) differs → produces OrgSpecV20250312Entry / TeamSpecV20250312Entry.
+			// Without neverSkipSegments the result would be OrgSpecEntry / TeamSpecEntry.
+			name:              "neverSkipSegments preserves shared version segment",
+			neverSkipPatterns: []string{"V[0-9]+"},
+			regsFn: func() []nameEngineReg {
+				entryA := NewStruct("Entry", []*GoField{NewGoField("X", NewPrimitive("string", StringKind))})
+				entryB := NewStruct("Entry", []*GoField{NewGoField("Y", NewPrimitive("string", StringKind))})
+				return []nameEngineReg{
+					{path: []string{"OrgSpec"}, gt: NewStruct("OrgSpec", []*GoField{NewGoField("Entry", entryA)})},
+					{path: []string{"TeamSpec"}, gt: NewStruct("TeamSpec", []*GoField{NewGoField("Entry", entryB)})},
+					{path: []string{"OrgSpec", "V20250312", "Entry"}, gt: entryA},
+					{path: []string{"TeamSpec", "V20250312", "Entry"}, gt: entryB},
+				}
+			},
+			want: []string{"OrgSpec", "OrgSpecV20250312Entry", "TeamSpec", "TeamSpecV20250312Entry"},
+		},
+		{
 			name: "duplicate root errors",
 			regsFn: func() []nameEngineReg {
 				team := newTestTeam()
@@ -486,6 +508,13 @@ func TestNameEngine(t *testing.T) {
 				existingNames, pinnedPaths := tt.setupFn(t)
 				ne.existingNames = existingNames
 				ne.pinnedPaths = pinnedPaths
+			}
+			if len(tt.neverSkipPatterns) > 0 {
+				compiled := make([]*regexp.Regexp, 0, len(tt.neverSkipPatterns))
+				for _, p := range tt.neverSkipPatterns {
+					compiled = append(compiled, regexp.MustCompile(p))
+				}
+				ne.neverSkipSegments = compiled
 			}
 			var regErr error
 			for _, r := range regs {

--- a/internal/gotype/naming_test.go
+++ b/internal/gotype/naming_test.go
@@ -329,6 +329,79 @@ func TestNameEngine(t *testing.T) {
 			want: []string{"Cluster", "Config", "Team"},
 		},
 		{
+			// SomeType.SomeTypeSpec.SubType.Leaf vs SomeOtherType.SomeOtherTypeSpec.SubType.Leaf
+			// Round 1 (immediate parent "SubType") is shared → skip.
+			// Round 2 ("SomeTypeSpec"/"SomeOtherTypeSpec") differs → use it.
+			name: "conflict skips shared intermediate segments",
+			regsFn: func() []nameEngineReg {
+				leafA := NewStruct("Leaf", []*GoField{NewGoField("X", NewPrimitive("string", StringKind))})
+				leafB := NewStruct("Leaf", []*GoField{NewGoField("Y", NewPrimitive("string", StringKind))})
+				return []nameEngineReg{
+					{path: []string{"SomeType"}, gt: NewStruct("SomeType", []*GoField{NewGoField("Leaf", leafA)})},
+					{path: []string{"SomeOtherType"}, gt: NewStruct("SomeOtherType", []*GoField{NewGoField("Leaf", leafB)})},
+					{path: []string{"SomeType", "SomeTypeSpec", "SubType", "Leaf"}, gt: leafA},
+					{path: []string{"SomeOtherType", "SomeOtherTypeSpec", "SubType", "Leaf"}, gt: leafB},
+				}
+			},
+			want: []string{"SomeOtherType", "SomeOtherTypeSpecLeaf", "SomeType", "SomeTypeSpecLeaf"},
+		},
+		{
+			// Three conflicting types under a shared root.
+			// Round 1 ("Sub") is shared → skip. Round 2 ("A"/"B"/"C") differs → use it.
+			name: "three-way conflict skips shared intermediate segment",
+			regsFn: func() []nameEngineReg {
+				leafA := NewStruct("Leaf", []*GoField{NewGoField("X", NewPrimitive("string", StringKind))})
+				leafB := NewStruct("Leaf", []*GoField{NewGoField("Y", NewPrimitive("string", StringKind))})
+				leafC := NewStruct("Leaf", []*GoField{NewGoField("Z", NewPrimitive("string", StringKind))})
+				root := NewStruct("Root", []*GoField{NewGoField("A", leafA), NewGoField("B", leafB), NewGoField("C", leafC)})
+				return []nameEngineReg{
+					{path: []string{"Root"}, gt: root},
+					{path: []string{"Root", "A", "Sub", "Leaf"}, gt: leafA},
+					{path: []string{"Root", "B", "Sub", "Leaf"}, gt: leafB},
+					{path: []string{"Root", "C", "Sub", "Leaf"}, gt: leafC},
+				}
+			},
+			want: []string{"Root", "ALeaf", "BLeaf", "CLeaf"},
+		},
+		{
+			// When round 1 is not sufficient, subsequent rounds accumulate until unique.
+			// Round 1 pos=1 ("X"/"Y"/"X") differs but leaves two "XLeaf"; round 2 pos=0
+			// ("A"/"A"/"B") then prepends on top → "AXLeaf","AYLeaf","BXLeaf".
+			name: "three-way conflict accumulates when single round insufficient",
+			regsFn: func() []nameEngineReg {
+				leafA := NewStruct("Leaf", []*GoField{NewGoField("X", NewPrimitive("string", StringKind))})
+				leafB := NewStruct("Leaf", []*GoField{NewGoField("Y", NewPrimitive("string", StringKind))})
+				leafC := NewStruct("Leaf", []*GoField{NewGoField("Z", NewPrimitive("string", StringKind))})
+				return []nameEngineReg{
+					{path: []string{"A"}, gt: NewStruct("A", []*GoField{NewGoField("X", leafA), NewGoField("Y", leafB)})},
+					{path: []string{"B"}, gt: NewStruct("B", []*GoField{NewGoField("X", leafC)})},
+					{path: []string{"A", "X", "Leaf"}, gt: leafA},
+					{path: []string{"A", "Y", "Leaf"}, gt: leafB},
+					{path: []string{"B", "X", "Leaf"}, gt: leafC},
+				}
+			},
+			want: []string{"A", "AXLeaf", "AYLeaf", "B", "BXLeaf"},
+		},
+		{
+			// Some.Deep.Path.FieldName vs Deep.Path.FieldName:
+			// Round 1 ("Path") shared → skip. Round 2 ("Deep") shared → skip.
+			// Round 3: c1 has "Some", c2 has "" (ran out of path) → differ.
+			// c1 gets "Some" prepended → SomeFieldName; c2 has no more ancestors → stays FieldName.
+			// The shallower type keeps the bare name; the deeper one is disambiguated.
+			name: "asymmetric depth: shallower candidate keeps bare name",
+			regsFn: func() []nameEngineReg {
+				fieldA := NewStruct("FieldName", []*GoField{NewGoField("X", NewPrimitive("string", StringKind))})
+				fieldB := NewStruct("FieldName", []*GoField{NewGoField("Y", NewPrimitive("string", StringKind))})
+				return []nameEngineReg{
+					{path: []string{"Some"}, gt: NewStruct("Some", []*GoField{NewGoField("FieldName", fieldA)})},
+					{path: []string{"Deep"}, gt: NewStruct("Deep", []*GoField{NewGoField("FieldName", fieldB)})},
+					{path: []string{"Some", "Deep", "Path", "FieldName"}, gt: fieldA},
+					{path: []string{"Deep", "Path", "FieldName"}, gt: fieldB},
+				}
+			},
+			want: []string{"Deep", "FieldName", "Some", "SomeFieldName"},
+		},
+		{
 			name: "duplicate root errors",
 			regsFn: func() []nameEngineReg {
 				team := newTestTeam()

--- a/internal/gotype/typedict.go
+++ b/internal/gotype/typedict.go
@@ -17,6 +17,7 @@ package gotype
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 
 	"github.com/crd2go/crd2go/pkg/config"
@@ -68,6 +69,23 @@ func WithPinnings(pinnings []string) TypeDictOption {
 	return func(td *TypeDict) {
 		if ne, ok := td.nameEngine.(*nameEngine); ok {
 			ne.pinnedPaths = pinned
+		}
+	}
+}
+
+// WithNeverSkipSegments returns a TypeDictOption that registers the given regex patterns.
+// Path segments matching any pattern are never skipped during conflict resolution,
+// even when all candidates share the same segment value. The canonical use case is
+// version segments (e.g. "V[0-9]+") which should be preserved for future naming stability.
+// Patterns must be valid RE2 regular expressions; invalid patterns cause a panic.
+func WithNeverSkipSegments(patterns []string) TypeDictOption {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		compiled = append(compiled, regexp.MustCompile(p))
+	}
+	return func(td *TypeDict) {
+		if ne, ok := td.nameEngine.(*nameEngine); ok {
+			ne.neverSkipSegments = compiled
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,7 @@ type CoreConfig struct {
 	SkipList           []string             `yaml:"skipList"`
 	Renames            map[string]string    `yaml:"renames"`
 	Pinnings           []string             `yaml:"pinnings"`
+	NeverSkipSegments  []string             `yaml:"neverSkipSegments"`
 	Imports            []ImportedTypeConfig `yaml:"imports"`
 	Plugins            []Plugin             `yaml:"plugins"`
 	DeepCopy           DeepCopy             `yaml:"deepCopy"`

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -85,7 +85,10 @@ func GenerateToDir(cfg *config.Config, forceRenames bool) error {
 	if cfg.Output == "" {
 		return fmt.Errorf("output directory is required")
 	}
-	opts := []gotype.TypeDictOption{gotype.WithPinnings(cfg.Pinnings)}
+	opts := []gotype.TypeDictOption{
+		gotype.WithPinnings(cfg.Pinnings),
+		gotype.WithNeverSkipSegments(cfg.NeverSkipSegments),
+	}
 	if !forceRenames {
 		existing, err := gotype.ScanExistingStructNames(cfg.Output)
 		if err != nil {

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -56,8 +56,10 @@ func TestGenerateFromCRDs(t *testing.T) {
 	in := bytes.NewBuffer(testdata.CRDsYAML)
 	req := gotype.Request{
 		CodeWriterFn: BufferForCRD(buffers),
-		TypeDict:     gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes()),
-		CoreConfig:   cfg.CoreConfig,
+		TypeDict: gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes(),
+			gotype.WithNeverSkipSegments(cfg.NeverSkipSegments),
+		),
+		CoreConfig: cfg.CoreConfig,
 	}
 	require.NoError(t, Generate(&req, in))
 


### PR DESCRIPTION
Solves #51 

The smart naming algorithm prepends the parent field names to the current name until the different types name collision is solved. This variant just skips prepending parent field names that do not help fixing the name conflict.

Eg.
- Some.Type.Deep.Path.FieldName
- Another.Type.Deep.Path.FieldName

Before:
- SomeTypeDeepPathFieldName
- AnotherTypeDeepPathFieldName

Now:
- SomeFieldName
- AnotherFieldName
