### PR TITLE
Support typed plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,28 @@ plugins:
       key: value
 ```
 
-Option values are typed (booleans, strings, numbers — not stringly-typed), and unknown keys are rejected at config-load time.
+#### Plugin options
+
+Plugin options are defined in YAML under each plugin:
+
+```yaml
+plugins:
+  - name: gen-client
+    options:
+      nonNamespaced: true
+```
+
+Options are parsed and validated when plugins are constructed, not during initial config load. The configuration loader preserves the raw YAML, and each plugin is responsible for decoding and validating its own options.
+
+For plugins that define typed options:
+
+- Unknown fields are rejected
+- Field types must match exactly (e.g. `true`, not `"true"`)
+- Invalid or unexpected shapes will result in an error when plugins are initialized
+
+For plugins that do not accept options:
+
+- Providing any options will result in an error
 
 #### `get-conditions`
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ plugins:
       nonNamespaced: true
 ```
 
-Options are parsed and validated when plugins are constructed, not during initial config load. The configuration loader preserves the raw YAML, and each plugin is responsible for decoding and validating its own options.
+The configuration loader preserves the raw YAML for each plugin's options; it does not validate them. Plugins are constructed once up-front, as soon as code generation starts, and each plugin decodes and validates its own options at that point. Any error surfaces before CRD processing begins rather than partway through rendering.
 
 For plugins that define typed options:
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Optional plugins extend the generated code on a per-CRD basis. Enable them in `c
 ```yaml
 plugins:
   - name: <plugin-name>
-    options:            # optional key/value pairs, plugin-specific
+    options:            # optional, plugin-specific; typed per plugin
       key: value
 ```
+
+Option values are typed (booleans, strings, numbers — not stringly-typed), and unknown keys are rejected at config-load time.
 
 #### `get-conditions`
 
@@ -81,9 +83,9 @@ plugins:
 
 The following option is supported:
 
-| Option | Values | Default | Description |
+| Option | Type | Default | Description |
 |---|---|---|---|
-| `nonNamespaced` | `"true"` / `"false"` | `"false"` | Adds `+genclient:nonNamespaced` for cluster-scoped resources. |
+| `nonNamespaced` | bool | `false` | Adds `+genclient:nonNamespaced` for cluster-scoped resources. |
 
 Example for a cluster-scoped resource:
 
@@ -91,10 +93,10 @@ Example for a cluster-scoped resource:
 plugins:
   - name: gen-client
     options:
-      nonNamespaced: "true"
+      nonNamespaced: true
 ```
 
-With `nonNamespaced: "true"` the generated file will contain:
+With `nonNamespaced: true` the generated file will contain:
 
 ```go
 // +genclient

--- a/crd2go.yaml
+++ b/crd2go.yaml
@@ -52,6 +52,9 @@ imports:
 # plugins customize what extra Go code gets generated on top of the CRD types
 plugins:
   - name: get-conditions
+#    - name: gen-client ## uncomment to enable gen-client plugin
+#      options:
+#        nonNamespaced: true
 
 # deepCopy controls whether +k8s:deepcopy-gen markers are emitted in the
 # generated code. Defaults to enabled (markers are emitted).

--- a/internal/plugins/genclient.go
+++ b/internal/plugins/genclient.go
@@ -28,10 +28,16 @@ type GenClient struct {
 	nonNamespaced bool
 }
 
-func newGenClientPlugin(cfg config.Plugin) Plugin {
-	return &GenClient{
-		nonNamespaced: cfg.Options["nonNamespaced"] == "true",
+type genClientOpts struct {
+	NonNamespaced bool `yaml:"nonNamespaced"`
+}
+
+func newGenClientPlugin(cfg config.Plugin) (Plugin, error) {
+	var opts genClientOpts
+	if err := decodePluginOptions(cfg, &opts); err != nil {
+		return nil, err
 	}
+	return &GenClient{nonNamespaced: opts.NonNamespaced}, nil
 }
 
 func (*GenClient) Name() string {

--- a/internal/plugins/genclient_test.go
+++ b/internal/plugins/genclient_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dave/jennifer/jen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/crd2go/crd2go/internal/plugins"
 	"github.com/crd2go/crd2go/pkg/config"
@@ -28,34 +29,34 @@ import (
 
 func TestGenClientAnnotate(t *testing.T) {
 	tests := []struct {
-		title   string
-		options map[string]string
-		wants   []string
-		notwant []string
+		title      string
+		optionsSrc string
+		wants      []string
+		notwant    []string
 	}{
 		{
-			title:   "no options produces +genclient only",
-			options: nil,
-			wants:   []string{"// +genclient"},
-			notwant: []string{"// +genclient:nonNamespaced"},
+			title:      "no options produces +genclient only",
+			optionsSrc: "",
+			wants:      []string{"// +genclient"},
+			notwant:    []string{"// +genclient:nonNamespaced"},
 		},
 		{
-			title:   "nonNamespaced false produces +genclient only",
-			options: map[string]string{"nonNamespaced": "false"},
-			wants:   []string{"// +genclient"},
-			notwant: []string{"// +genclient:nonNamespaced"},
+			title:      "nonNamespaced false produces +genclient only",
+			optionsSrc: "nonNamespaced: false",
+			wants:      []string{"// +genclient"},
+			notwant:    []string{"// +genclient:nonNamespaced"},
 		},
 		{
-			title:   "nonNamespaced true produces both markers",
-			options: map[string]string{"nonNamespaced": "true"},
-			wants:   []string{"// +genclient", "// +genclient:nonNamespaced"},
+			title:      "nonNamespaced true produces both markers",
+			optionsSrc: "nonNamespaced: true",
+			wants:      []string{"// +genclient", "// +genclient:nonNamespaced"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.title, func(t *testing.T) {
 			pluginList, err := plugins.CodegenPlugins([]config.Plugin{
-				{Name: "gen-client", Options: tc.options},
+				{Name: "gen-client", Options: pluginOptionsFromYAML(t, tc.optionsSrc)},
 			})
 			require.NoError(t, err)
 			require.Len(t, pluginList, 1)
@@ -73,6 +74,35 @@ func TestGenClientAnnotate(t *testing.T) {
 			for _, notwant := range tc.notwant {
 				assert.NotContains(t, output, notwant)
 			}
+		})
+	}
+}
+
+func TestGenClientOptionsErrors(t *testing.T) {
+	tests := []struct {
+		title      string
+		optionsSrc string
+		wantErr    string
+	}{
+		{
+			title:      "unknown field is rejected",
+			optionsSrc: "nonNamspaced: true", // typo
+			wantErr:    "field nonNamspaced not found",
+		},
+		{
+			title:      "wrong type is rejected",
+			optionsSrc: `nonNamespaced: "true"`, // quoted string, not bool
+			wantErr:    "cannot unmarshal",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			_, err := plugins.CodegenPlugins([]config.Plugin{
+				{Name: "gen-client", Options: pluginOptionsFromYAML(t, tc.optionsSrc)},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
 }
@@ -109,4 +139,19 @@ func TestGenClientAnnotateIsBeforeType(t *testing.T) {
 	genClientPos := bytes.Index(buf.Bytes(), []byte("+genclient"))
 	typePos := bytes.Index(buf.Bytes(), []byte("type MyKind"))
 	assert.Greater(t, typePos, genClientPos, "+genclient marker must appear before the type definition\n%s", output)
+}
+
+// pluginOptionsFromYAML parses a YAML fragment into the yaml.Node shape a
+// plugin would receive from config load. An empty src returns a zero node,
+// matching the "options omitted" case.
+func pluginOptionsFromYAML(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if src == "" {
+		return node
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(src), &node))
+	require.Equal(t, yaml.DocumentNode, node.Kind)
+	require.Len(t, node.Content, 1)
+	return *node.Content[0]
 }

--- a/internal/plugins/getconditions.go
+++ b/internal/plugins/getconditions.go
@@ -20,6 +20,8 @@ import (
 	"unicode"
 
 	"github.com/dave/jennifer/jen"
+
+	"github.com/crd2go/crd2go/pkg/config"
 )
 
 const (
@@ -27,6 +29,13 @@ const (
 )
 
 type GetConditions struct {
+}
+
+func newGetConditionsPlugin(cfg config.Plugin) (Plugin, error) {
+	if err := decodePluginOptions(cfg, &struct{}{}); err != nil {
+		return nil, err
+	}
+	return &GetConditions{}, nil
 }
 
 func (*GetConditions) Name() string {

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -52,7 +52,7 @@ func CodegenPlugins(configs []config.Plugin) ([]Plugin, error) {
 		}
 		plugin, err := builder(cfg)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("plugin %q: %w", cfg.Name, err)
 		}
 		plugins = append(plugins, plugin)
 	}
@@ -68,12 +68,12 @@ func decodePluginOptions(cfg config.Plugin, out any) error {
 	}
 	buf, err := yaml.Marshal(&cfg.Options)
 	if err != nil {
-		return fmt.Errorf("plugin %q: re-encode options: %w", cfg.Name, err)
+		return fmt.Errorf("re-encode options: %w", err)
 	}
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
 	dec.KnownFields(true)
 	if err := dec.Decode(out); err != nil {
-		return fmt.Errorf("plugin %q: decode options: %w", cfg.Name, err)
+		return fmt.Errorf("decode options: %w", err)
 	}
 	return nil
 }

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -63,7 +63,7 @@ func CodegenPlugins(configs []config.Plugin) ([]Plugin, error) {
 // so unknown fields produce an error. An empty options node is treated as
 // a no-op, leaving out at its zero value.
 func decodePluginOptions(cfg config.Plugin, out any) error {
-	if cfg.Options.Kind == 0 {
+	if cfg.Options.IsZero() {
 		return nil
 	}
 	buf, err := yaml.Marshal(&cfg.Options)

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -15,9 +15,11 @@
 package plugins
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/dave/jennifer/jen"
+	"gopkg.in/yaml.v3"
 
 	"github.com/crd2go/crd2go/internal/gotype"
 	"github.com/crd2go/crd2go/pkg/config"
@@ -34,13 +36,11 @@ type Plugin interface {
 	Annotate(f *jen.File, kind string) error
 }
 
-type PluginBuilderFunc func(config.Plugin) Plugin
+type PluginBuilderFunc func(config.Plugin) (Plugin, error)
 
 var codegenPlugins = map[string]PluginBuilderFunc{
-	GetConditionsPlugin: func(config.Plugin) Plugin {
-		return &GetConditions{}
-	},
-	GenClientPlugin: newGenClientPlugin,
+	GetConditionsPlugin: newGetConditionsPlugin,
+	GenClientPlugin:     newGenClientPlugin,
 }
 
 func CodegenPlugins(configs []config.Plugin) ([]Plugin, error) {
@@ -50,8 +50,30 @@ func CodegenPlugins(configs []config.Plugin) ([]Plugin, error) {
 		if !ok {
 			return nil, fmt.Errorf("%q is not a registered plugin", cfg.Name)
 		}
-		plugin := builder(cfg)
+		plugin, err := builder(cfg)
+		if err != nil {
+			return nil, err
+		}
 		plugins = append(plugins, plugin)
 	}
 	return plugins, nil
+}
+
+// decodePluginOptions decodes cfg.Options into out using strict decoding,
+// so unknown fields produce an error. An empty options node is treated as
+// a no-op, leaving out at its zero value.
+func decodePluginOptions(cfg config.Plugin, out any) error {
+	if cfg.Options.Kind == 0 {
+		return nil
+	}
+	buf, err := yaml.Marshal(&cfg.Options)
+	if err != nil {
+		return fmt.Errorf("plugin %q: re-encode options: %w", cfg.Name, err)
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(buf))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil {
+		return fmt.Errorf("plugin %q: decode options: %w", cfg.Name, err)
+	}
+	return nil
 }

--- a/internal/render/jen.go
+++ b/internal/render/jen.go
@@ -122,11 +122,7 @@ func renderCRDListObject(f *jen.File, kind string) {
 // renderAnnotationPlugins runs all plugins' Annotate method before the type
 // definition, allowing them to add markers/comments above the root kind struct.
 func renderAnnotationPlugins(f *jen.File, req *CRDRenderRequest) error {
-	codeGenPlugins, err := plugins.CodegenPlugins(req.Plugins)
-	if err != nil {
-		return fmt.Errorf("failed to enumerate codegen plugins: %w", err)
-	}
-	for _, plugin := range codeGenPlugins {
+	for _, plugin := range req.BuiltPlugins {
 		if err := plugin.Annotate(f, req.Kind); err != nil {
 			return fmt.Errorf("failed to annotate with plugin %q: %w", plugin.Name(), err)
 		}
@@ -136,15 +132,11 @@ func renderAnnotationPlugins(f *jen.File, req *CRDRenderRequest) error {
 
 // renderCodegenPlugins appends code generation from optional plugins per CRD
 func renderCodegenPlugins(f *jen.File, req *CRDRenderRequest) error {
-	codeGenPlugins, err := plugins.CodegenPlugins(req.Plugins)
-	if err != nil {
-		return fmt.Errorf("failed to enumerate codegen plugins: %w", err)
-	}
 	pluginRequest := plugins.CodegenRequest{
 		File: f,
 		Type: req.Type,
 	}
-	for _, plugin := range codeGenPlugins {
+	for _, plugin := range req.BuiltPlugins {
 		if err := plugin.Process(&pluginRequest); err != nil {
 			return fmt.Errorf("failed to process plugin %q: %w", plugin.Name(), err)
 		}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -17,16 +17,21 @@ package render
 
 import (
 	"github.com/crd2go/crd2go/internal/gotype"
+	"github.com/crd2go/crd2go/internal/plugins"
 )
 
+// CRDRenderRequest carries everything RenderCRD needs for a single CRD,
+// including the pre-constructed plugin list. BuiltPlugins is populated once
+// up-front so hooks aren't re-decoding options for every CRD.
 type CRDRenderRequest struct {
 	gotype.Request
-	Filename string
-	Group    string
-	Version  string
-	Kind     string
-	Resource string
-	Type     *gotype.GoType
+	Filename     string
+	Group        string
+	Version      string
+	Kind         string
+	Resource     string
+	Type         *gotype.GoType
+	BuiltPlugins []plugins.Plugin
 }
 
 type CRD2GoRenderer interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,8 @@ package config
 
 import (
 	"io"
+
+	"gopkg.in/yaml.v3"
 )
 
 // CodeWriterFunc is a function type that takes a CRD and returns a writer for the generated code
@@ -56,10 +58,12 @@ type CoreConfig struct {
 	GroupVersion       string               `yaml:"-"`
 }
 
-// Plugin represents a named plugin code that can be optionally invoked
+// Plugin represents a named plugin code that can be optionally invoked.
+// Options holds the raw YAML node for plugin-specific options; each plugin
+// decodes it into its own typed struct at registration time.
 type Plugin struct {
-	Name    string            `yaml:"name"`
-	Options map[string]string `yaml:"options"`
+	Name    string    `yaml:"name"`
+	Options yaml.Node `yaml:"options"`
 }
 
 // DeepCopy controls whether deepcopy markers are emitted in the generated code.

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -31,6 +31,7 @@ import (
 	"github.com/crd2go/crd2go/internal/crd/hooks"
 	"github.com/crd2go/crd2go/internal/fileinput"
 	"github.com/crd2go/crd2go/internal/gotype"
+	"github.com/crd2go/crd2go/internal/plugins"
 	"github.com/crd2go/crd2go/internal/render"
 	"github.com/crd2go/crd2go/pkg/config"
 )
@@ -109,9 +110,25 @@ func GenerateToDir(cfg *config.Config, forceRenames bool) error {
 	return nil
 }
 
-// Generate will write files using the CodeWriterFunc
+// Prepare constructs the plugin list once from req.Plugins. Any error decoding
+// plugin options surfaces here, before any CRD is parsed or rendered. Call
+// this after loading the config and before Generate or GenerateStream.
+func Prepare(req *gotype.Request) ([]plugins.Plugin, error) {
+	builtPlugins, err := plugins.CodegenPlugins(req.Plugins)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct plugins: %w", err)
+	}
+	return builtPlugins, nil
+}
+
+// Generate will write files using the CodeWriterFunc. It runs Prepare
+// internally, so callers don't need to construct plugins themselves.
 func Generate(req *gotype.Request, r io.Reader) error {
-	generatedGVRs, err := GenerateStream(req, r)
+	builtPlugins, err := Prepare(req)
+	if err != nil {
+		return err
+	}
+	generatedGVRs, err := GenerateStream(req, builtPlugins, r)
 	if err != nil {
 		return fmt.Errorf("failed to generate CRDs: %w", err)
 	}
@@ -134,10 +151,15 @@ func Generate(req *gotype.Request, r io.Reader) error {
 }
 
 // GenerateStream generates Go code from a stream of CRDs within a YAML reader.
-// It uses the provided CodeWriterFunc to write the generated code to the specified output.
-// The version parameter specifies the version of the CRD to generate code for.
-// The preloadedTypes parameter allows for preloading specific types to avoid name collisions.
-func GenerateStream(req *gotype.Request, r io.Reader) ([]string, error) {
+// It uses the provided CodeWriterFunc to write the generated code to the
+// specified output. The version parameter specifies the version of the CRD to
+// generate code for. The preloadedTypes parameter allows for preloading
+// specific types to avoid name collisions.
+//
+// builtPlugins must be produced by Prepare (or plugins.CodegenPlugins
+// directly). This function does not build plugins itself — do that up-front
+// so errors surface before CRD processing.
+func GenerateStream(req *gotype.Request, builtPlugins []plugins.Plugin, r io.Reader) ([]string, error) {
 	preloaded := []*gotype.GoType{}
 	for _, name := range req.Reserved {
 		preloaded = append(preloaded, gotype.NewOpaqueType(name))
@@ -147,7 +169,7 @@ func GenerateStream(req *gotype.Request, r io.Reader) ([]string, error) {
 	}
 	req.TypeDict.AddAll(preloaded...)
 
-	renderRequests, err := computeRenderRequests(req, bufio.NewScanner(r))
+	renderRequests, err := computeRenderRequests(req, builtPlugins, bufio.NewScanner(r))
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate CRDs code generation information: %w", err)
 	}
@@ -172,7 +194,7 @@ func GenerateStream(req *gotype.Request, r io.Reader) ([]string, error) {
 	return generatedGVRs, nil
 }
 
-func computeRenderRequests(req *gotype.Request, scanner *bufio.Scanner) ([]render.CRDRenderRequest, error) {
+func computeRenderRequests(req *gotype.Request, builtPlugins []plugins.Plugin, scanner *bufio.Scanner) ([]render.CRDRenderRequest, error) {
 	renderRequests := []render.CRDRenderRequest{}
 	group, version, err := selectGroupVersion(req)
 	if err != nil {
@@ -217,13 +239,14 @@ func computeRenderRequests(req *gotype.Request, scanner *bufio.Scanner) ([]rende
 				group, version, versionedCRD.Version.Name, crdSchema.Spec.Group)
 		}
 		renderReq := render.CRDRenderRequest{
-			Request:  *req,
-			Filename: crd.Kind2Filename(versionedCRD.Kind),
-			Group:    crdSchema.Spec.Group,
-			Version:  versionedCRD.Version.Name,
-			Kind:     versionedCRD.Kind,
-			Resource: crdSchema.Spec.Names.Plural,
-			Type:     goCRD,
+			Request:      *req,
+			Filename:     crd.Kind2Filename(versionedCRD.Kind),
+			Group:        crdSchema.Spec.Group,
+			Version:      versionedCRD.Version.Name,
+			Kind:         versionedCRD.Kind,
+			Resource:     crdSchema.Spec.Names.Plural,
+			Type:         goCRD,
+			BuiltPlugins: builtPlugins,
 		}
 		renderRequests = append(renderRequests, renderReq)
 	}

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -128,7 +128,9 @@ func TestRefs(t *testing.T) {
 			SkipList: disabledKinds,
 		},
 	}
-	_, err := GenerateStream(&req, in)
+	builtPlugins, err := Prepare(&req)
+	require.NoError(t, err)
+	_, err = GenerateStream(&req, builtPlugins, in)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, buffers)

--- a/pkg/crd2go/crd2go_test.go
+++ b/pkg/crd2go/crd2go_test.go
@@ -25,16 +25,28 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/dave/jennifer/jen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/crd2go/crd2go/internal/checkerr"
 	"github.com/crd2go/crd2go/internal/crd"
 	"github.com/crd2go/crd2go/internal/gotype"
+	"github.com/crd2go/crd2go/internal/plugins"
 	"github.com/crd2go/crd2go/internal/testdata"
 	"github.com/crd2go/crd2go/k8s"
 	"github.com/crd2go/crd2go/pkg/config"
 )
+
+// pluginsFromYAML parses a YAML fragment like "- name: foo\n  options: {...}"
+// into a []config.Plugin, matching what LoadConfig would produce.
+func pluginsFromYAML(t *testing.T, src string) []config.Plugin {
+	t.Helper()
+	var plugins []config.Plugin
+	require.NoError(t, yaml.Unmarshal([]byte(src), &plugins))
+	return plugins
+}
 
 const (
 	expectedSources = 19
@@ -226,8 +238,11 @@ func TestGenerateWithGenClient(t *testing.T) {
 			wantGenClient: true,
 		},
 		{
-			name:              "gen-client nonNamespaced produces both markers",
-			plugins:           []config.Plugin{{Name: "gen-client", Options: map[string]string{"nonNamespaced": "true"}}},
+			name: "gen-client nonNamespaced produces both markers",
+			plugins: pluginsFromYAML(t, `
+- name: gen-client
+  options:
+    nonNamespaced: true`),
 			wantGenClient:     true,
 			wantNonNamespaced: true,
 		},
@@ -454,20 +469,6 @@ imports: []`,
 			},
 		},
 		{
-			name: "gen-client plugin with options",
-			input: `plugins:
-  - name: gen-client
-    options:
-      nonNamespaced: "true"`,
-			want: &config.Config{
-				CoreConfig: config.CoreConfig{
-					Plugins: []config.Plugin{
-						{Name: "gen-client", Options: map[string]string{"nonNamespaced": "true"}},
-					},
-				},
-			},
-		},
-		{
 			name:    "bad yaml",
 			input:   "this is not a good YAML config",
 			wantErr: "cannot unmarshal",
@@ -493,6 +494,35 @@ imports: []`,
 			}
 		})
 	}
+}
+
+// TestLoadConfigPluginOptions checks that plugin options survive the
+// YAML → CoreConfig → CodegenPlugins round trip and decode into the
+// plugin's typed options. Direct struct equality on yaml.Node is fragile
+// (line/column metadata), so this test validates the observable behaviour
+// of the loaded plugin rather than the raw config shape.
+func TestLoadConfigPluginOptions(t *testing.T) {
+	input := `plugins:
+  - name: gen-client
+    options:
+      nonNamespaced: true`
+
+	cfg, err := LoadConfig(bytes.NewBufferString(input))
+	require.NoError(t, err)
+	require.Len(t, cfg.Plugins, 1)
+	assert.Equal(t, "gen-client", cfg.Plugins[0].Name)
+
+	// The observable check: the plugin actually carries the nonNamespaced
+	// flag across the load boundary and emits the matching marker.
+	pluginList, err := plugins.CodegenPlugins(cfg.Plugins)
+	require.NoError(t, err)
+	require.Len(t, pluginList, 1)
+
+	f := jen.NewFile("v1")
+	require.NoError(t, pluginList[0].Annotate(f, "MyKind"))
+	var out bytes.Buffer
+	require.NoError(t, f.Render(&out))
+	assert.Contains(t, out.String(), "+genclient:nonNamespaced")
 }
 
 func TestCodeFileForCRDAtPath(t *testing.T) {


### PR DESCRIPTION
So more advanced plugins can be supported.

Note that as plugin options are typed, a boolean now does not use quotes:

Before:
```yaml
plugins:
  - name: gen-client
     options:
       nonNamespaced: "true"
```

Now:
```yaml
plugins:
  - name: gen-client
     options:
       nonNamespaced: true
```

This change also moves plugin instantiation up front to be done only once, at load config time.