### PR TITLE
Make generated filenames configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Extra configuration settings:
 - *reserved* is an array of type names that are not to be used in code generation.
 - *renames* are key - value pairs that specify how each key typename should be renamed to the given value when generated.
 - *imports* associate a type name with an import path and alias, so that an existing Go type is used instead of further expanding a CRD defined type in the generated code.
+- *fileNameFormat* used to name the generated files. The .go extension is always appended.
 - *plugins* is an array that opts into extra output. See **Plugins** below — deepcopy and apply-configuration marker generation are now plugins (`gen-deepcopy`, `gen-applyconfiguration`).
 
 **Deprecated**: *deepCopy.generate* and *applyConfiguration* as top-level settings are deprecated; use the `gen-deepcopy` and `gen-applyconfiguration` plugins instead. The legacy fields still work but emit a warning to stderr. Setting a legacy field alongside its equivalent plugin is an error.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Extra configuration settings:
 
 ```yaml
 fileNameFormat: "%s_types"   #  filename output becomes mycrd_types.go, doc_types.go and groupversion_info_types.go
+```
 
 **Deprecated**: *deepCopy.generate* and *applyConfiguration* as top-level settings are deprecated; use the `gen-deepcopy` and `gen-applyconfiguration` plugins instead. The legacy fields still work but emit a warning to stderr. Setting a legacy field alongside its equivalent plugin is an error.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Extra configuration settings:
 - *reserved* is an array of type names that are not to be used in code generation.
 - *renames* are key - value pairs that specify how each key typename should be renamed to the given value when generated.
 - *imports* associate a type name with an import path and alias, so that an existing Go type is used instead of further expanding a CRD defined type in the generated code.
-- *fileNameFormat* used to name the generated files. The .go extension is always appended.
+- *fileNameFormat* used to name the generated files. `%s` is replaced by the lowercased Kind and the .go extension is always appended. When set, the format must contain `%s`, otherwise all Kinds would target the same file. When unset, files are named after the Kind alone:
+
+```yaml
+fileNameFormat: "%s_types"   #  filename output becomes mycrd_types.go, doc_types.go and groupversion_info_types.go
+fileNameFormat: "%s_generated"   #  filename output becomes mycrd_generated.go, doc_generated.go and groupversion_info_generated.go
+```
 - *plugins* is an array that opts into extra output. See **Plugins** below — deepcopy and apply-configuration marker generation are now plugins (`gen-deepcopy`, `gen-applyconfiguration`).
 
 **Deprecated**: *deepCopy.generate* and *applyConfiguration* as top-level settings are deprecated; use the `gen-deepcopy` and `gen-applyconfiguration` plugins instead. The legacy fields still work but emit a warning to stderr. Setting a legacy field alongside its equivalent plugin is an error.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Extra configuration settings:
 
 ```yaml
 fileNameFormat: "%s_types"   #  filename output becomes mycrd_types.go, doc_types.go and groupversion_info_types.go
-fileNameFormat: "%s_generated"   #  filename output becomes mycrd_generated.go, doc_generated.go and groupversion_info_generated.go
-```
 - *plugins* is an array that opts into extra output. See **Plugins** below — deepcopy and apply-configuration marker generation are now plugins (`gen-deepcopy`, `gen-applyconfiguration`).
 
 **Deprecated**: *deepCopy.generate* and *applyConfiguration* as top-level settings are deprecated; use the `gen-deepcopy` and `gen-applyconfiguration` plugins instead. The legacy fields still work but emit a warning to stderr. Setting a legacy field alongside its equivalent plugin is an error.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Extra configuration settings:
 
 ```yaml
 fileNameFormat: "%s_types"   #  filename output becomes mycrd_types.go, doc_types.go and groupversion_info_types.go
-- *plugins* is an array that opts into extra output. See **Plugins** below — deepcopy and apply-configuration marker generation are now plugins (`gen-deepcopy`, `gen-applyconfiguration`).
 
 **Deprecated**: *deepCopy.generate* and *applyConfiguration* as top-level settings are deprecated; use the `gen-deepcopy` and `gen-applyconfiguration` plugins instead. The legacy fields still work but emit a warning to stderr. Setting a legacy field alongside its equivalent plugin is an error.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crd2go/crd2go
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/dave/jennifer v1.7.1

--- a/internal/crd/crd.go
+++ b/internal/crd/crd.go
@@ -69,8 +69,15 @@ func FromOpenAPIType(td *gotype.TypeDict, hooks []OpenAPI2GoHook, crdType *CRDTy
 	return nil, fmt.Errorf("unsupported Open API type %q", crdType.Name)
 }
 
-func Kind2Filename(kind string) string {
-	return fmt.Sprintf("%s.go", strings.ToLower(kind))
+func Filename(base, format string) string {
+	if format == "" {
+		format = "%s"
+	}
+	return fmt.Sprintf(format, base) + ".go"
+}
+
+func Kind2Filename(kind, format string) string {
+	return Filename(strings.ToLower(kind), format)
 }
 
 func IsPrimitive(crdType *CRDType) bool {

--- a/internal/crd/crd_test.go
+++ b/internal/crd/crd_test.go
@@ -413,3 +413,8 @@ func CrossReference() *gotype.GoType {
 func LocalReference() *gotype.GoType {
 	return gotype.MustTypeFrom(reflect.TypeOf(k8s.LocalReference{}))
 }
+
+func TestKind2Filename(t *testing.T) {
+	assert.Equal(t, "myapiresource.go", crd.Kind2Filename("MyAPIResource", ""))
+	assert.Equal(t, "myapiresource_types.go", crd.Kind2Filename("MyAPIResource", "%s_types"))
+}

--- a/internal/render/jen.go
+++ b/internal/render/jen.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/crd2go/crd2go/internal/checkerr"
+	"github.com/crd2go/crd2go/internal/crd"
 	"github.com/crd2go/crd2go/internal/gotype"
 	"github.com/crd2go/crd2go/internal/plugins"
 )
@@ -151,12 +152,13 @@ func renderDocFile(req *gotype.Request, builtPlugins []plugins.Plugin, group, ve
 	}
 	f.HeaderComment(fmt.Sprintf("+groupName=%s", group))
 
-	wc, err := req.CodeWriterFn("doc.go", false)
+	name := crd.Filename("doc", req.FileNameFormat)
+	wc, err := req.CodeWriterFn(name, false)
 	if err != nil {
-		return fmt.Errorf("failed to prepare doc.go for writing: %w", err)
+		return fmt.Errorf("failed to prepare %s for writing: %w", name, err)
 	}
 	if err := f.Render(wc); err != nil {
-		return fmt.Errorf("failed to write Go code to doc.go: %w", err)
+		return fmt.Errorf("failed to write Go code to %s: %w", name, err)
 	}
 	return nil
 }
@@ -198,12 +200,13 @@ func renderSchemeFile(req *gotype.Request, builtPlugins []plugins.Plugin, group,
 
 	f.Var().Defs(varDefs...)
 
-	wc, err := req.CodeWriterFn("groupversion_info.go", true)
+	name := crd.Filename("groupversion_info", req.FileNameFormat)
+	wc, err := req.CodeWriterFn(name, true)
 	if err != nil {
-		return fmt.Errorf("failed to prepare groupversion_info.go for writing: %w", err)
+		return fmt.Errorf("failed to prepare %s for writing: %w", name, err)
 	}
 	if err := f.Render(wc); err != nil {
-		return fmt.Errorf("failed to write Go code to groupversion_info.go: %w", err)
+		return fmt.Errorf("failed to write Go code to %s: %w", name, err)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ type CoreConfig struct {
 	Plugins            []Plugin             `yaml:"plugins"`
 	DeepCopy           DeepCopy             `yaml:"deepCopy"`
 	ApplyConfiguration ApplyConfiguration   `yaml:"applyConfiguration"`
+	FileNameFormat     string               `yaml:"fileNameFormat"`
 	GroupVersion       string               `yaml:"-"`
 }
 

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -99,7 +99,7 @@ func GenerateToDir(cfg *config.Config, forceRenames bool) error {
 	case strings.Contains(fileNameFormat, "%s"):
 	default:
 		return fmt.Errorf(
-			"fileNameFormat %q must contain %%s to generate a distinct file for each kind",
+			"when set, fileNameFormat %q must contain %%s to generate a distinct file for each kind",
 			fileNameFormat,
 		)
 	}

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -99,15 +99,13 @@ func GenerateToDir(cfg *config.Config, forceRenames bool) error {
 		return nil
 	}
 
-	if strings.Contains(fileNameFormat, "%s") {
-		return nil
-	}
-
-	return fmt.Errorf(
-		"fileNameFormat %q must contain %%s to generate a distinct file for each kind",
-		fileNameFormat,
-	)
-	td := gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes(), opts...)
+	if !strings.Contains(fileNameFormat, "%s") {
+		return fmt.Errorf(
+		  "fileNameFormat %q must contain %%s to generate a distinct file for each kind",
+		  fileNameFormat,
+	    )
+	} 
+td := gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes(), opts...)
 	in, err := os.Open(cfg.Input)
 	if err != nil {
 		return fmt.Errorf("failed to open input file %s: %w", cfg.Input, err)

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -94,18 +94,16 @@ func GenerateToDir(cfg *config.Config, forceRenames bool) error {
 		}
 		opts = append(opts, gotype.WithExistingNames(existing))
 	}
-	fileNameFormat := cfg.FileNameFormat
-	if fileNameFormat == "" {
-		return nil
-	}
-
-	if !strings.Contains(fileNameFormat, "%s") {
+	switch fileNameFormat := cfg.FileNameFormat; {
+	case fileNameFormat == "":
+	case strings.Contains(fileNameFormat, "%s"):
+	default:
 		return fmt.Errorf(
-		  "fileNameFormat %q must contain %%s to generate a distinct file for each kind",
-		  fileNameFormat,
-	    )
-	} 
-td := gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes(), opts...)
+			"fileNameFormat %q must contain %%s to generate a distinct file for each kind",
+			fileNameFormat,
+		)
+	}
+	td := gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes(), opts...)
 	in, err := os.Open(cfg.Input)
 	if err != nil {
 		return fmt.Errorf("failed to open input file %s: %w", cfg.Input, err)

--- a/pkg/crd2go/crd2go.go
+++ b/pkg/crd2go/crd2go.go
@@ -94,6 +94,19 @@ func GenerateToDir(cfg *config.Config, forceRenames bool) error {
 		}
 		opts = append(opts, gotype.WithExistingNames(existing))
 	}
+	fileNameFormat := cfg.FileNameFormat
+	if fileNameFormat == "" {
+		return nil
+	}
+
+	if strings.Contains(fileNameFormat, "%s") {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"fileNameFormat %q must contain %%s to generate a distinct file for each kind",
+		fileNameFormat,
+	)
 	td := gotype.NewTypeDict(cfg.Renames, gotype.KnownTypes(), opts...)
 	in, err := os.Open(cfg.Input)
 	if err != nil {
@@ -340,7 +353,7 @@ func computeRenderRequests(req *gotype.Request, scanner *bufio.Scanner) ([]rende
 		}
 		renderReq := render.CRDRenderRequest{
 			Request:  *req,
-			Filename: crd.Kind2Filename(versionedCRD.Kind),
+			Filename: crd.Kind2Filename(versionedCRD.Kind, req.FileNameFormat),
 			Group:    crdSchema.Spec.Group,
 			Version:  versionedCRD.Version.Name,
 			Kind:     versionedCRD.Kind,


### PR DESCRIPTION
## Problem

The generated filenames are currently hardcoded:

- internal/crd/crd.go generates <lowercased kind>.go
- internal/render/jen.go writes doc.go and groupversion_info.go directly.

The configuration therefore does not provide any way to customise these filenames.

In my operator's naming convention, I want to use generated in the filename to distinguish generated files from handwritten ones:

- s3tenant.generated.go
- doc.generated.go
- groupversion_info.generated.go

The .generated.go suffix is then used in my Makefile and by review tooling to distinguish generated files from files written manually.

The same requirement exists for the kubebuilder <kind>_types.go convention.

At the moment, the only solution is to rename the files after each generation:
    go tool crd2go -config crd2go.yaml -gv storagegrid.example.io/v1alpha1
    mv api/v1alpha1/s3tenant.go          api/v1alpha1/s3tenant.generated.go
    mv api/v1alpha1/doc.go               api/v1alpha1/doc.generated.go
    mv api/v1alpha1/groupversion_info.go api/v1alpha1/groupversion_info.generated.go

I find this approach fragile:

- the rename logic has to be duplicated in every Makefile or CI job that regenerates the code
- a newly added Kind can easily be missed
- an old <kind>.go file can remain behind if a rename step is forgotten.

Since the generator is already responsible for choosing the output filenames, I think this convention should be handled directly by the tool rather than through a post-processing step.

## Change

I therefore propose adding a fileNameFormat configuration field, allowing users to control the names of generated files.
I also propose that the .go extension should always be appended automatically by the generator.